### PR TITLE
Add sudo back in to post-create command

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "🔓 Fixing permissions of ${PNPM_STORE}"
 
-chown -R node:node "${PNPM_STORE}"
+sudo chown -R node:node "${PNPM_STORE}"
 export PNPM_HOME="${HOME}/.local/share/pnpm"
 export PATH="$PNPM_HOME:$PATH"
 pnpm config set store-dir "$PNPM_STORE" # This comes from devcontainer.json, and is mounted as a volume in docker-compose.yaml


### PR DESCRIPTION
Despite what CodeRabbit said, it's required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved permission handling for the package store directory to ensure smoother setup in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->