### PR TITLE
Get rid of ...

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,7 +23,7 @@
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["exec", "turbo", "run", "dev", "--filter", "web..."],
+      "runtimeArgs": ["exec", "turbo", "run", "dev", "--filter", "web"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "restart": false,
@@ -40,7 +40,7 @@
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "pnpm",
-      "runtimeArgs": ["exec", "turbo", "run", "dev", "--filter", "api..."],
+      "runtimeArgs": ["exec", "turbo", "run", "dev", "--filter", "api"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
       "restart": false

--- a/turbo.json
+++ b/turbo.json
@@ -33,6 +33,10 @@
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
     "dev": {
+      "dependsOn": [
+        "@workspace/validators#build",
+        "@workspace/plantools#build"
+      ],
       "env": ["MONGO_DB_CONNECTION_STRING", "MONGO_DB_NAME", "API_BASE_URL"],
       "persistent": true,
       "cache": false


### PR DESCRIPTION
No idea why, but using `...` breaks launch.json module loading. Get rid of it, explicitly add `build` as dependencies of `dev`.

This does mean that any changes to the validator or plantools package will need to be rebuilt before the api or web projects see it.