### PR TITLE
Revert turbo watch for running in dev

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "Clearance Lab (All)",
       "type": "node-terminal",
-      "command": "pnpx turbo watch dev",
+      "command": "pnpx turbo run dev",
       "request": "launch",
       "serverReadyAction": {
         "pattern": "- Local:.+(https?://.+)",
@@ -17,7 +17,7 @@
     {
       "name": "Clearance Lab (Web)",
       "type": "node-terminal",
-      "command": "pnpx turbo watch dev --filter web",
+      "command": "pnpx turbo run dev --filter web",
       "internalConsoleOptions": "neverOpen",
       "request": "launch",
       "serverReadyAction": {
@@ -31,7 +31,7 @@
     {
       "name": "Clearance Lab (API)",
       "type": "node-terminal",
-      "command": "pnpx turbo watch dev --filter api",
+      "command": "pnpx turbo run dev --filter api",
       "request": "launch"
     }
   ]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "dev": "tsup --onSuccess \"node dist/index.js\"",
+    "dev": "tsup --watch --onSuccess \"node dist/index.js\"",
     "dev:docker": "BUILDKIT_PROGRESS=plain docker compose run api",
     "ci": "pnpm run build",
     "start": "node dist/index.js",

--- a/turbo.json
+++ b/turbo.json
@@ -37,8 +37,7 @@
       "dependsOn": ["^dev-setup"],
       "env": ["MONGO_DB_CONNECTION_STRING", "MONGO_DB_NAME", "API_BASE_URL"],
       "persistent": true,
-      "cache": false,
-      "interruptible": true
+      "cache": false
     }
   }
 }


### PR DESCRIPTION
`turbo watch` was killing the API server on any Next.JS rebuilds. No bueno.

Go bac to using `tsup --watch` for the API server and `turbo run` for launch configs. Might revisit this some other time, there really isn't a dependency between Next.JS and web, so maybe they need to be two separate turbo commands? 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated development scripts and configurations for improved watch mode and command consistency.
	- Adjusted launch settings for local development environments.
	- Removed an obsolete property from the development task configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->