### PR TITLE
Add a dialog that imports the data

### DIFF
--- a/apps/web/src/components/scenario-form/actions.ts
+++ b/apps/web/src/components/scenario-form/actions.ts
@@ -36,12 +36,21 @@ function assertObject(
 export async function fetchPlanByCallsign(
   callsign: string
 ): Promise<FetchPlanByCallsignState> {
-  const plan = await apiFetch<Plan>(`/vatsim/flightplan/${callsign}`);
+  const requestedCallsign = callsign.toUpperCase().trim();
+
+  if (!requestedCallsign) {
+    return {
+      success: false,
+      message: "Please enter a callsign.",
+    };
+  }
+
+  const plan = await apiFetch<Plan>(`/vatsim/flightplan/${requestedCallsign}`);
 
   if (!plan) {
     return {
       success: false,
-      message: `No flight plan found for ${callsign}.`,
+      message: `No flight plan found for ${requestedCallsign}.`,
     };
   }
 

--- a/apps/web/src/components/scenario-form/plan-section.tsx
+++ b/apps/web/src/components/scenario-form/plan-section.tsx
@@ -23,7 +23,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { PasteScenarioDialog } from "./paste-scenario-dialog";
+import { VatsimImportDialog } from "./vatsim-import-dialog";
 import { ScenarioInput } from "@workspace/validators";
 
 export function PlanSection() {
@@ -327,8 +327,8 @@ export function PlanSection() {
           </div>
         </div>
       </CardContent>
-      <CardFooter>
-        <PasteScenarioDialog />
+      <CardFooter className="space-x-2">
+        <VatsimImportDialog />
       </CardFooter>
     </Card>
   );

--- a/apps/web/src/components/scenario-form/scenario-overview.tsx
+++ b/apps/web/src/components/scenario-form/scenario-overview.tsx
@@ -76,7 +76,7 @@ export function ScenarioOverview() {
                   <FormControl>
                     <Input
                       id="airportConditions"
-                      placeholder="West flow, altimeter 29.92, departure 124.350."
+                      placeholder="West flow. Altimeter 29.92. Departure 124.350."
                       {...field}
                     />
                   </FormControl>

--- a/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
+++ b/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
@@ -42,7 +42,12 @@ export function VatsimImportDialog() {
         return;
       }
 
-      // Populate the fields with the values from the VATSIM flight plan
+      // Reset and close the dialog.
+      resetDialog();
+      setOpen(false);
+
+      // Populate the fields with the values from the VATSIM flight plan.
+      // This happens after the dialog is closed to make it feel more responsive.
       setValue("plan.aid", result.plan.aid);
       setValue("plan.alt", result.plan.alt);
       setValue("plan.bcn", result.plan.bcn);
@@ -56,9 +61,6 @@ export function VatsimImportDialog() {
       setValue("plan.typ", result.plan.typ);
       setValue("plan.vatsimId", result.plan.vatsimId);
       setValue("plan.pilotName", result.plan.pilotName);
-
-      // Reset and close the dialog.
-      setOpen(false);
     });
   }
 

--- a/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
+++ b/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
@@ -1,0 +1,113 @@
+import { useState, useTransition } from "react";
+import { Button } from "../ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "../ui/dialog";
+import { AlertTriangleIcon, ImportIcon, Loader2 } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "../ui/alert";
+import { Input } from "@/components/ui/input";
+import { useFormContext } from "react-hook-form";
+import { fetchPlanByCallsign } from "./actions";
+
+export function VatsimImportDialog() {
+  const [callsign, setCallsign] = useState("");
+  const [open, setOpen] = useState(false);
+  const [errorContent, setErrorContent] = useState<React.ReactNode>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const { setValue } = useFormContext();
+
+  function handleImport() {
+    startTransition(async () => {
+      const result = await fetchPlanByCallsign(callsign.toUpperCase());
+
+      if (!result.success) {
+        setErrorContent(result.message);
+        return;
+      }
+
+      // Populate the fields with the values from the VATSIM flight plan
+      setValue("plan.aid", result.plan.aid);
+      setValue("plan.alt", result.plan.alt);
+      setValue("plan.bcn", result.plan.bcn);
+      setValue("plan.cid", result.plan.cid);
+      setValue("plan.dep", result.plan.dep);
+      setValue("plan.dest", result.plan.dest);
+      setValue("plan.eq", result.plan.eq);
+      setValue("plan.rmk", result.plan.rmk);
+      setValue("plan.rte", result.plan.rte);
+      setValue("plan.spd", result.plan.spd);
+      setValue("plan.typ", result.plan.typ);
+      setValue("plan.vatsimId", result.plan.vatsimId);
+      setValue("plan.pilotName", result.plan.pilotName);
+
+      // Reset and close the dialog.
+      setCallsign("");
+      setErrorContent(null);
+      setOpen(false);
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button
+          variant="outline"
+          onClick={() => {
+            setOpen(true);
+          }}
+        >
+          <ImportIcon />
+          Import from VATSIM
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Import flight plan from VATSIM</DialogTitle>
+          <DialogDescription>
+            Enter the callsign for an active VATSIM flight, then press{" "}
+            <b>Import</b> to populate the flight plan with the values.
+          </DialogDescription>
+        </DialogHeader>
+        <Input
+          placeholder="SWA2878"
+          value={callsign}
+          required
+          onChange={(e) => {
+            setCallsign(e.target.value);
+          }}
+        />
+        {errorContent && (
+          <Alert variant="error">
+            <AlertTriangleIcon className="h-4 w-4" />
+            <AlertTitle>Unable to import scenario</AlertTitle>
+            <AlertDescription>{errorContent}</AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter>
+          {isPending ? (
+            <Button disabled className="w-[120px]">
+              <Loader2 className="animate-spin" />
+              Importing...
+            </Button>
+          ) : (
+            <Button
+              onClick={handleImport}
+              disabled={isPending}
+              className="w-[120px]"
+            >
+              Import
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
+++ b/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
@@ -23,7 +23,17 @@ export function VatsimImportDialog() {
 
   const { setValue } = useFormContext();
 
+  function resetDialog() {
+    setCallsign("");
+    setErrorContent(null);
+  }
+
   function handleImport() {
+    if (!callsign) {
+      setErrorContent("Please enter a callsign.");
+      return;
+    }
+
     startTransition(async () => {
       const result = await fetchPlanByCallsign(callsign.toUpperCase());
 
@@ -48,14 +58,20 @@ export function VatsimImportDialog() {
       setValue("plan.pilotName", result.plan.pilotName);
 
       // Reset and close the dialog.
-      setCallsign("");
-      setErrorContent(null);
       setOpen(false);
     });
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(isOpen) => {
+        setOpen(isOpen);
+        if (!isOpen) {
+          resetDialog();
+        }
+      }}
+    >
       <DialogTrigger asChild>
         <Button
           variant="outline"
@@ -86,7 +102,7 @@ export function VatsimImportDialog() {
         {errorContent && (
           <Alert variant="error">
             <AlertTriangleIcon className="h-4 w-4" />
-            <AlertTitle>Unable to import scenario</AlertTitle>
+            <AlertTitle>Unable to import flight plan</AlertTitle>
             <AlertDescription>{errorContent}</AlertDescription>
           </Alert>
         )}

--- a/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
+++ b/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
@@ -94,9 +94,16 @@ export function VatsimImportDialog() {
         <Input
           placeholder="SWA2878"
           value={callsign}
+          aria-label="Callsign"
           required
           onChange={(e) => {
             setCallsign(e.target.value);
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              handleImport();
+            }
           }}
         />
         {errorContent && (
@@ -107,7 +114,7 @@ export function VatsimImportDialog() {
           </Alert>
         )}
 
-        <DialogFooter>
+        <DialogFooter aria-live="polite">
           {isPending ? (
             <Button disabled className="w-[120px]">
               <Loader2 className="animate-spin" />
@@ -116,8 +123,8 @@ export function VatsimImportDialog() {
           ) : (
             <Button
               onClick={handleImport}
-              disabled={isPending}
               className="w-[120px]"
+              aria-label="Import flight plan from VATSIM"
             >
               Import
             </Button>


### PR DESCRIPTION
Fixes #194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to import flight plan data from VATSIM by callsign via a new dialog interface.
  - Introduced direct fetching of flight plans by callsign with success and error handling states.
- **User Interface**
  - Replaced the previous scenario import dialog with a VATSIM import dialog in the plan section.
  - Improved layout spacing in the plan section footer for better visual clarity.
- **Enhancements**
  - Updated placeholder text formatting for airport conditions for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->