### PR TITLE
Fix CRAFT section not showing in some scenarios

### DIFF
--- a/apps/web/src/components/problems/problems.tsx
+++ b/apps/web/src/components/problems/problems.tsx
@@ -16,8 +16,12 @@ export function Problems({ scenario }: ProblemsProps) {
 
   return (
     <div>
-      {(scenario.problems.length === 0 || scenario.canClear) && (
+      {scenario.canClear ? (
         <CalloutBox level="ok">You can issue the clearance!</CalloutBox>
+      ) : (
+        <CalloutBox level="warning">
+          You cannot issue the clearance yet.
+        </CalloutBox>
       )}
 
       <div className="mt-2">


### PR DESCRIPTION
Fixes #207

This was because the scenarios couldn't be cleared but didn't have any problems listed. This resulted in:

* The "you can clear message" showing, because it had an `||` test for an empty problem list
* There were no problems, so no problems showed
* canClear was false, so CRAFT didn't show

This was legacy garbage from when canClear was a calculated property instead of explicitly being set. 