### PR TITLE
Fix caching once and for all

### DIFF
--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    },
+    "ci": {
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "ci": {
+      "outputs": [".next/**", "!.next/cache/**"]
+    }
+  }
+}

--- a/packages/plantools/turbo.json
+++ b/packages/plantools/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    },
+    "ci": {
+      "outputs": ["dist/**"]
+    },
+    "dev-setup": {
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/packages/validators/turbo.json
+++ b/packages/validators/turbo.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "outputs": ["dist/**"]
+    },
+    "ci": {
+      "outputs": ["dist/**"]
+    },
+    "dev-setup": {
+      "outputs": ["dist/**"]
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -4,8 +4,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "env": ["MONGO_DB_CONNECTION_STRING", "MONGO_DB_NAME", "API_BASE_URL"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "env": ["MONGO_DB_CONNECTION_STRING", "MONGO_DB_NAME", "API_BASE_URL"]
     },
     "cf-deploy": {
       "dependsOn": [
@@ -29,12 +28,10 @@
     },
     "ci": {
       "dependsOn": ["^ci"],
-      "env": ["MONGO_DB_CONNECTION_STRING", "MONGO_DB_NAME", "API_BASE_URL"],
-      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+      "env": ["MONGO_DB_CONNECTION_STRING", "MONGO_DB_NAME", "API_BASE_URL"]
     },
     "dev-setup": {
-      "dependsOn": ["^dev-setup"],
-      "cache": false
+      "dependsOn": ["^dev-setup"]
     },
     "dev": {
       "dependsOn": ["^dev-setup"],


### PR DESCRIPTION
The issue was bad `outputs` configurations for the various projects. The cache for the packages was an empty zip, so when it *looked* like it was replaying the cache it was just pasting in the old log messages and extracting... nothing.

Fixed by putting specific `turbo.json` files in each project that explicitly list what the outputs are for each project. Fixed!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added new Turbo configuration files for API, web, plantools, and validators to define build and output settings.
  - Updated the main Turbo configuration by removing output and cache properties from specific tasks to streamline build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->