### PR TITLE
Domain doesn't have to be an URL

### DIFF
--- a/apps/web/src/lib/env.ts
+++ b/apps/web/src/lib/env.ts
@@ -22,9 +22,7 @@ const envSchema = z.object({
   AUTH0_AUDIENCE: z.string(),
   AUTH0_CLIENT_SECRET: z.string(), // To generate this use `openssl rand -hex 32`
   AUTH0_CLIENT_ID: z.string(),
-  AUTH0_DOMAIN: z
-    .string()
-    .url({ message: "AUTH0_DOMAIN must be a valid URL." }),
+  AUTH0_DOMAIN: z.string(),
   AUTH0_SECRET: z.string(),
   APP_BASE_URL: z
     .string()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated environment variable validation for `AUTH0_DOMAIN` to remove URL format enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->