### PR TITLE
Strip periods from the route portion of craft

### DIFF
--- a/apps/api/src/models/scenario.ts
+++ b/apps/api/src/models/scenario.ts
@@ -71,6 +71,13 @@ ScenarioSchema.pre("save", function (next) {
     logger.debug(`Normalized route from "${originalRoute}" to "${this.craft.route}"`);
   }
 
+  // Strip periods off some of the CRAFT properties.
+  if (this.craft) {
+    this.craft.altitude = this.craft.altitude?.replace(/\.$/, "");
+    this.craft.clearanceLimit = this.craft.clearanceLimit?.replace(/\.$/, "");
+    this.craft.route = this.craft.route?.replace(/\.$/, "");
+  }
+
   next();
 });
 


### PR DESCRIPTION
Fixes #290

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data consistency by automatically removing trailing periods from certain craft details (altitude, clearance limit, and route) when saving scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->