### PR TITLE
Import current altimeter from vatsim

### DIFF
--- a/.devcontainer/seed/clearancelab.metars.json
+++ b/.devcontainer/seed/clearancelab.metars.json
@@ -1,0 +1,16 @@
+[{
+  "_id": {
+    "$oid": "64f67f368558cd6698857155"
+  },
+  "icao": "KPDX",
+  "metar": "KPDX 300153Z 35007G20KT 9SM FEW065 17/04 A3017 RMK AO2 SLP216 T01670044",
+  "source": "Vatsim",
+  "createdAt": {
+    "$date": "2023-09-05T01:07:02.681Z"
+  },
+  "updatedAt": {
+    "$date": "2025-04-30T02:44:50.590Z"
+  },
+  "altimeter": 30.17,
+  "__v": 0
+}]

--- a/.devcontainer/seed/clearancelab.metars.json
+++ b/.devcontainer/seed/clearancelab.metars.json
@@ -1,16 +1,12 @@
-[{
-  "_id": {
-    "$oid": "64f67f368558cd6698857155"
-  },
-  "icao": "KPDX",
-  "metar": "KPDX 300153Z 35007G20KT 9SM FEW065 17/04 A3017 RMK AO2 SLP216 T01670044",
-  "source": "Vatsim",
-  "createdAt": {
-    "$date": "2023-09-05T01:07:02.681Z"
-  },
-  "updatedAt": {
-    "$date": "2025-04-30T02:44:50.590Z"
-  },
-  "altimeter": 30.17,
-  "__v": 0
-}]
+[
+  {
+    "__v": 0,
+    "_id": {
+      "$oid": "64f67f368558cd6698857155"
+    },
+    "altimeter": 30.17,
+    "icao": "KPDX",
+    "metar": "KPDX 300153Z 35007G20KT 9SM FEW065 17/04 A3017 RMK AO2 SLP216 T01670044",
+    "source": "Vatsim"
+  }
+]

--- a/.devcontainer/seed/init.sh
+++ b/.devcontainer/seed/init.sh
@@ -12,3 +12,4 @@ mongoimport --quiet --uri="${DB_URI}" --collection=scenarios --file="${SCRIPT_DI
 mongoimport --quiet --uri="${DB_URI}" --collection=airportinfo --file="${SCRIPT_DIR}/clearancelab.airportinfo.json" --jsonArray
 mongoimport --quiet --uri="${DB_URI}" --collection=vatsimflightplans --file="${SCRIPT_DIR}/clearancelab.vatsimflightplans.json" --jsonArray
 mongoimport --quiet --uri="${DB_URI}" --collection=auth0users --file="${SCRIPT_DIR}/clearancelab.auth0users.json" --jsonArray
+mongoimport --quiet --uri="${DB_URI}" --collection=metars --file="${SCRIPT_DIR}/clearancelab.metars.json" --jsonArray

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,6 +29,7 @@
     "Hoverable",
     "interruptible",
     "logform",
+    "Metar",
     "mongoimport",
     "mongosh",
     "nextjs",

--- a/apps/api/src/models/metar.ts
+++ b/apps/api/src/models/metar.ts
@@ -1,0 +1,20 @@
+import mongoose, { Schema } from "mongoose";
+
+export interface IMetar {
+  icao: string;
+  metar: string;
+  source: string;
+  altimeter?: number;
+}
+
+const MetarSchema = new Schema<IMetar>(
+  {
+    icao: { type: String, required: true },
+    metar: { type: String, required: true },
+    source: { type: String, required: true },
+    altimeter: { type: Number, required: false },
+  },
+  { timestamps: true },
+);
+
+export const Metar = mongoose.model<IMetar>("Metar", MetarSchema);

--- a/apps/api/src/routes/vatsim.ts
+++ b/apps/api/src/routes/vatsim.ts
@@ -1,4 +1,9 @@
-import { getRandomBcn, getRandomCid, getRandomName, getRandomVatsimId } from "@workspace/plantools";
+import {
+  getRandomBcn,
+  getRandomCid,
+  getRandomName,
+  getRandomVatsimId,
+} from "@workspace/plantools";
 import { Plan } from "@workspace/validators";
 import { NextFunction, Request, Response, Router } from "express";
 import { verifyApiKey } from "../middleware/apikey.js";
@@ -36,6 +41,7 @@ router.get(
         eq: flightPlan.equipmentSuffix,
         homeAirport: flightPlan.homeAirport,
         vatsimId: getRandomVatsimId(),
+        altimeter: flightPlan.metar?.altimeter,
       } as Plan;
 
       response.json(returnedFlightPlan);

--- a/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
+++ b/apps/web/src/components/scenario-form/vatsim-import-dialog.tsx
@@ -1,4 +1,5 @@
 import { Input } from "@/components/ui/input";
+import { getRandomAltimeter } from "@workspace/plantools";
 import { AlertTriangleIcon, ImportIcon, Loader2 } from "lucide-react";
 import { useState, useTransition } from "react";
 import { useFormContext } from "react-hook-form";
@@ -61,6 +62,10 @@ export function VatsimImportDialog() {
       setValue("plan.typ", result.plan.typ);
       setValue("plan.vatsimId", result.plan.vatsimId);
       setValue("plan.pilotName", result.plan.pilotName);
+      setValue(
+        "airportConditions.altimeter",
+        result.plan.altimeter ?? getRandomAltimeter(),
+      );
     });
   }
 
@@ -89,8 +94,8 @@ export function VatsimImportDialog() {
         <DialogHeader>
           <DialogTitle>Import flight plan from VATSIM</DialogTitle>
           <DialogDescription>
-            Enter the callsign for an active VATSIM flight, then press <b>Import</b> to populate the
-            flight plan with the values.
+            Enter the callsign for an active VATSIM flight, then press{" "}
+            <b>Import</b> to populate the flight plan with the values.
           </DialogDescription>
         </DialogHeader>
         <Input

--- a/packages/validators/src/plan.ts
+++ b/packages/validators/src/plan.ts
@@ -15,6 +15,7 @@ export const PlanSchema = z.object({
   spd: z.coerce.number().optional(),
   typ: z.string().optional(),
   vatsimId: z.coerce.number(),
+  altimeter: z.coerce.number().optional(),
 });
 
 export type Plan = z.infer<typeof PlanSchema>;


### PR DESCRIPTION
Fixes #274 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for storing and retrieving METAR weather data, including altimeter settings, for airports.
  - Flight plan data now includes associated METAR information, such as the altimeter value, when available.
  - Importing a flight plan from VATSIM will now set the altimeter field in the scenario form, using the METAR value or a random fallback.

- **Bug Fixes**
  - Improved spell checker configuration to recognize the term "Metar" and prevent false spelling errors.

- **Chores**
  - Updated seed data and import scripts to include sample METAR weather information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->