### PR TITLE
Show "offline" in CRAFT breakdown if there's no departure frequency

### DIFF
--- a/apps/web/src/components/answer.tsx
+++ b/apps/web/src/components/answer.tsx
@@ -56,7 +56,9 @@ export function Answer({ scenario }: AnswerProperties) {
                 </TableRow>
                 <TableRow key="F">
                   <TableCell>F</TableCell>
-                  <TableCell>{scenario.craft?.frequency}</TableCell>
+                  <TableCell>
+                    {scenario.craft?.frequency ?? "offline"}
+                  </TableCell>
                 </TableRow>
                 <TableRow key="T">
                   <TableCell>T</TableCell>


### PR DESCRIPTION
Fixes #323

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display of the frequency field in the clearance details table by showing "offline" when no value is set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->