### PR TITLE
Add links to skyvector and flightaware

### DIFF
--- a/apps/web/src/components/fpe/fpe.tsx
+++ b/apps/web/src/components/fpe/fpe.tsx
@@ -91,7 +91,7 @@ const FPE = ({ scenario }: FPEProperties) => {
           {skyVectorUrl && flightAwareUrl ? (
             <TooltipProvider aria-label="Additional information">
               <Tooltip>
-                <TooltipTrigger className="underline decoration-[var(--color-fpe-foreground)] decoration-dotted decoration-[2px] underline-offset-[4px] cursor-help">
+                <TooltipTrigger className="underline decoration-[var(--color-fpe-foreground)] decoration-dotted decoration-[2px] underline-offset-[4px] cursor-pointer">
                   RTE
                 </TooltipTrigger>
                 <TooltipContent

--- a/apps/web/src/components/fpe/fpe.tsx
+++ b/apps/web/src/components/fpe/fpe.tsx
@@ -1,7 +1,15 @@
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utilities";
+import { getFlightAwareUrl, getSkyVectorUrl } from "@workspace/plantools";
 import { Scenario } from "@workspace/validators";
 import * as changeCase from "change-case";
 import { useCallback, useState } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "../ui/tooltip";
 import { FPEBox } from "./fpe-box";
 import { FPEInput } from "./fpe-input";
 import { FPELabel } from "./fpe-label";
@@ -23,6 +31,9 @@ const FPE = ({ scenario }: FPEProperties) => {
   const handleAmend = useCallback(() => {
     setIsDirty(false);
   }, []);
+
+  const skyVectorUrl = getSkyVectorUrl(plan);
+  const flightAwareUrl = getFlightAwareUrl(plan);
 
   return (
     <div className="w-[800px] mt-2 mb-2">
@@ -76,7 +87,48 @@ const FPE = ({ scenario }: FPEProperties) => {
           ALT
         </FPELabel>
         <FPELabel id="fpe-rte-label" className="fpe-rte-label text-right py-1">
-          RTE
+          {skyVectorUrl && flightAwareUrl ? (
+            <TooltipProvider aria-label="Additional information">
+              <Tooltip>
+                <TooltipTrigger className="underline underline-dotted cursor-help">
+                  RTE
+                </TooltipTrigger>
+                <TooltipContent
+                  className="bg-popover fill-[var(--color-popover)]"
+                  side="right"
+                >
+                  {skyVectorUrl && (
+                    <p>
+                      <Button variant="link">
+                        <a
+                          href={skyVectorUrl ?? ""}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          View on SkyVector
+                        </a>
+                      </Button>
+                    </p>
+                  )}
+                  {flightAwareUrl && (
+                    <p>
+                      <Button variant="link">
+                        <a
+                          href={flightAwareUrl ?? ""}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          View on FlightAware
+                        </a>
+                      </Button>
+                    </p>
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            "RTE"
+          )}
         </FPELabel>
         <FPELabel id="fpe-rmk-label" className="fpe-rmk-label text-right py-1">
           RMK

--- a/apps/web/src/components/fpe/fpe.tsx
+++ b/apps/web/src/components/fpe/fpe.tsx
@@ -105,6 +105,7 @@ const FPE = ({ scenario }: FPEProperties) => {
                           href={skyVectorUrl ?? ""}
                           target="_blank"
                           rel="noreferrer"
+                          aria-label="View flight plan on SkyVector, opens in new tab"
                         >
                           View on SkyVector
                         </a>
@@ -118,6 +119,7 @@ const FPE = ({ scenario }: FPEProperties) => {
                           href={flightAwareUrl ?? ""}
                           target="_blank"
                           rel="noreferrer"
+                          aria-label="View flight plan on FlightAware, opens in new tab"
                         >
                           View on FlightAware
                         </a>

--- a/apps/web/src/components/fpe/fpe.tsx
+++ b/apps/web/src/components/fpe/fpe.tsx
@@ -20,6 +20,7 @@ interface FPEProperties {
   scenario?: Scenario | undefined;
 }
 
+// The dotted underline under RTE comes from https://notchtools.com/css-underline-generator
 const FPE = ({ scenario }: FPEProperties) => {
   const { plan, airportConditions } = scenario ?? {};
   const [isDirty, setIsDirty] = useState(false);
@@ -90,7 +91,7 @@ const FPE = ({ scenario }: FPEProperties) => {
           {skyVectorUrl && flightAwareUrl ? (
             <TooltipProvider aria-label="Additional information">
               <Tooltip>
-                <TooltipTrigger className="underline underline-dotted cursor-help">
+                <TooltipTrigger className="underline decoration-[var(--color-fpe-foreground)] decoration-dotted decoration-[2px] underline-offset-[4px] cursor-help">
                   RTE
                 </TooltipTrigger>
                 <TooltipContent

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -18,7 +18,9 @@ function TooltipProvider({
   );
 }
 
-function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
     <TooltipProvider>
       <TooltipPrimitive.Root data-slot="tooltip" {...props} />
@@ -26,7 +28,9 @@ function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root
   );
 }
 
-function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
 }
 
@@ -48,7 +52,12 @@ function TooltipContent({
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow
+          className={cn(
+            "bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]",
+            className,
+          )}
+        />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   );

--- a/packages/plantools/src/formatting.ts
+++ b/packages/plantools/src/formatting.ts
@@ -1,4 +1,4 @@
-import { Scenario } from "@workspace/validators";
+import { Plan, Scenario } from "@workspace/validators";
 
 const AirlineCodeRegexPattern = /\b([A-Za-z]{3})([A-Za-z\d]+)\b/;
 
@@ -73,4 +73,44 @@ export const getWeightClass = (equipmentType: string) => {
   if (equipmentType.startsWith("S/")) {
     return "Super";
   }
+};
+
+/**
+ * Returns the FlightAware URL for the flight based on departure and destination.
+ * @param scenario The scenario object containing information about the flight
+ * @returns The FlightAware URL as a string
+ */
+export const getFlightAwareUrl = (plan: Plan | undefined) => {
+  if (!plan) {
+    return;
+  }
+
+  const { dep, dest } = plan;
+
+  if (!dep || !dest) {
+    return;
+  }
+
+  return `https://flightaware.com/analysis/route.rvt?origin=${dep}&destination=${dest}`;
+};
+
+/**
+ * Returns the SkyVector URL for the flight based on departure, route, and destination.
+ * @param scenario The scenario object containing information about the flight
+ * @returns The SkyVector URL as a string
+ */
+export const getSkyVectorUrl = (plan: Plan | undefined) => {
+  if (!plan) {
+    return;
+  }
+
+  const { dep, dest, rte } = plan;
+
+  if (!dep || !dest || !rte) {
+    return;
+  }
+
+  const flightPlanString = `${dep} ${rte} ${dest}`;
+
+  return `https://skyvector.com/?fpl=${encodeURIComponent(flightPlanString)}`;
 };


### PR DESCRIPTION
Fixes #332 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added external links to SkyVector and FlightAware for flight plan data, accessible via a tooltip in the "RTE" label when both URLs are available.
  - Tooltip includes clickable buttons that open the respective sites in new tabs for easy access to additional flight information.

- **Style**
  - Enhanced the "RTE" label with a dotted underline and interactive tooltip for improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->