### PR TITLE
Add a fancy table to the admin page with a list of all scenarios

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -29,7 +29,6 @@ pnpm --silent add -g @devcontainers/cli
 pnpm --silent install --frozen-lockfile
 
 ### Database setup
-echo "📦 Seeding database..."
 "${SCRIPT_DIR}/seed/init.sh"
 
 ### Aliases

--- a/.devcontainer/seed/init.sh
+++ b/.devcontainer/seed/init.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+echo "📦 Seeding database..."
+
 # Initialize the database
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
         "action": "debugWithEdge",
         "killOnServerStop": true,
         "pattern": "- Local:.+(https?://.+)",
-        "uriFormat": "%s/lab/6802cf01cd28e1a43a89e8da",
+        "uriFormat": "%s/admin/scenarios",
         "webRoot": "${workspaceFolder}/apps/web/src"
       },
       "type": "node-terminal"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,16 @@
       "label": "Lint everything",
       "problemMatcher": ["$eslint-stylish"],
       "type": "shell"
+    },
+    {
+      "command": "./.devcontainer/seed/init.sh",
+      "group": {
+        "isDefault": false,
+        "kind": "build"
+      },
+      "label": "Re-initialize the database",
+      "problemMatcher": [],
+      "type": "shell"
     }
   ],
   "version": "2.0.0"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,6 +31,7 @@
     "@radix-ui/react-slot": "^1.2.0",
     "@radix-ui/react-switch": "^1.2.2",
     "@radix-ui/react-tooltip": "^1.2.0",
+    "@tanstack/react-table": "^8.21.3",
     "@workspace/plantools": "workspace:*",
     "@workspace/validators": "workspace:*",
     "change-case": "^5.4.4",

--- a/apps/web/src/api/scenarios/fetch-scenarios.tsx
+++ b/apps/web/src/api/scenarios/fetch-scenarios.tsx
@@ -4,6 +4,7 @@ import { getJson } from "@/lib/api";
 import {
   fetchScenariosResponseSchema,
   fetchScenariosSummaryResponseSchema,
+  ScenarioResponse,
 } from "@workspace/validators";
 
 /**
@@ -14,7 +15,13 @@ export const fetchScenarios = async () => {
   const response = await getJson("/scenarios");
 
   if (!response.ok) {
-    throw new Error("Failed to fetch full scenario list.");
+    console.error("Failed to fetch scenarios:", response.statusText);
+    const fetchResponse: ScenarioResponse = {
+      success: false,
+      message: "Failed to fetch scenarios.",
+    };
+
+    return fetchResponse;
   }
 
   const data = await response.json();

--- a/apps/web/src/app/admin/scenarios/columns.tsx
+++ b/apps/web/src/app/admin/scenarios/columns.tsx
@@ -37,7 +37,6 @@ const columns = [
       return (
         <RowActions
           scenarioId={scenario._id}
-          onDelete={() => console.log("Delete", scenario._id)}
         />
       );
     },

--- a/apps/web/src/app/admin/scenarios/columns.tsx
+++ b/apps/web/src/app/admin/scenarios/columns.tsx
@@ -9,21 +9,33 @@ const columnHelper = createColumnHelper<Scenario>();
 const columns = [
   columnHelper.accessor("plan.aid", {
     id: "plan.aid",
-    header: () => <div aria-sort="none">Callsign</div>,
+    header: () => (
+      <div aria-sort="none" className="uppercase">
+        Callsign
+      </div>
+    ),
     cell: (info) => <div>{info.getValue()}</div>,
     enableSorting: false,
     enableHiding: false,
   }),
   columnHelper.accessor("plan.dep", {
     id: "plan.dep",
-    header: () => <div aria-sort="none">Departure</div>,
+    header: () => (
+      <div aria-sort="none" className="uppercase">
+        Departure
+      </div>
+    ),
     cell: (info) => <div>{info.getValue()}</div>,
     enableSorting: false,
     enableHiding: false,
   }),
   columnHelper.accessor("plan.dest", {
     id: "plan.dest",
-    header: () => <div aria-sort="none">Arrival</div>,
+    header: () => (
+      <div aria-sort="none" className="uppercase">
+        Arrival
+      </div>
+    ),
     cell: (info) => <div>{info.getValue()}</div>,
     enableSorting: false,
     enableHiding: false,
@@ -31,7 +43,7 @@ const columns = [
   columnHelper.accessor("plan.rte", {
     id: "plan.rte",
     header: () => (
-      <div className="text-left" aria-sort="none">
+      <div className="text-left uppercase" aria-sort="none">
         Route
       </div>
     ),

--- a/apps/web/src/app/admin/scenarios/columns.tsx
+++ b/apps/web/src/app/admin/scenarios/columns.tsx
@@ -7,38 +7,45 @@ import { RowActions } from "./row-actions";
 const columnHelper = createColumnHelper<Scenario>();
 
 const columns = [
+  columnHelper.accessor("plan.aid", {
+    id: "plan.aid",
+    header: () => <div aria-sort="none">Callsign</div>,
+    cell: (info) => <div>{info.getValue()}</div>,
+    enableSorting: false,
+    enableHiding: false,
+  }),
   columnHelper.accessor("plan.dep", {
     id: "plan.dep",
-    header: "Departure",
-    cell: (info) => <div className="text-left">{info.getValue()}</div>,
-    enableSorting: true,
+    header: () => <div aria-sort="none">Departure</div>,
+    cell: (info) => <div>{info.getValue()}</div>,
+    enableSorting: false,
     enableHiding: false,
   }),
   columnHelper.accessor("plan.dest", {
     id: "plan.dest",
-    header: "Arrival",
-    cell: (info) => <div className="text-left">{info.getValue()}</div>,
-    enableSorting: true,
+    header: () => <div aria-sort="none">Arrival</div>,
+    cell: (info) => <div>{info.getValue()}</div>,
+    enableSorting: false,
     enableHiding: false,
   }),
   columnHelper.accessor("plan.rte", {
     id: "plan.rte",
-    header: () => <div className="text-left">Route</div>,
+    header: () => (
+      <div className="text-left" aria-sort="none">
+        Route
+      </div>
+    ),
     cell: (info) => (
       <div className="text-left whitespace-normal">{info.getValue()}</div>
     ),
-    enableSorting: true,
+    enableSorting: false,
     enableHiding: false,
   }),
   columnHelper.display({
     id: "actions",
     cell: ({ row }) => {
       const scenario = row.original;
-      return (
-        <RowActions
-          scenarioId={scenario._id}
-        />
-      );
+      return <RowActions scenarioId={scenario._id} />;
     },
   }),
 ] as ColumnDef<Scenario>[];

--- a/apps/web/src/app/admin/scenarios/columns.tsx
+++ b/apps/web/src/app/admin/scenarios/columns.tsx
@@ -15,7 +15,7 @@ const columns = [
     enableHiding: false,
   }),
   columnHelper.accessor("plan.dest", {
-    id: "plan.arr",
+    id: "plan.dest",
     header: "Arrival",
     cell: (info) => <div className="text-left">{info.getValue()}</div>,
     enableSorting: true,

--- a/apps/web/src/app/admin/scenarios/columns.tsx
+++ b/apps/web/src/app/admin/scenarios/columns.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { createColumnHelper, type ColumnDef } from "@tanstack/react-table";
+import { Scenario } from "@workspace/validators";
+import { RowActions } from "./row-actions";
+
+const columnHelper = createColumnHelper<Scenario>();
+
+const columns = [
+  columnHelper.accessor("plan.dep", {
+    id: "plan.dep",
+    header: "Departure",
+    cell: (info) => <div className="text-left">{info.getValue()}</div>,
+    enableSorting: true,
+    enableHiding: false,
+  }),
+  columnHelper.accessor("plan.dest", {
+    id: "plan.arr",
+    header: "Arrival",
+    cell: (info) => <div className="text-left">{info.getValue()}</div>,
+    enableSorting: true,
+    enableHiding: false,
+  }),
+  columnHelper.accessor("plan.rte", {
+    id: "plan.rte",
+    header: () => <div className="text-left">Route</div>,
+    cell: (info) => (
+      <div className="text-left whitespace-normal">{info.getValue()}</div>
+    ),
+    enableSorting: true,
+    enableHiding: false,
+  }),
+  columnHelper.display({
+    id: "actions",
+    cell: ({ row }) => {
+      const scenario = row.original;
+      return (
+        <RowActions
+          scenarioId={scenario._id}
+          onDelete={() => console.log("Delete", scenario._id)}
+        />
+      );
+    },
+  }),
+] as ColumnDef<Scenario>[];
+
+export const defaultColumns = columns;

--- a/apps/web/src/app/admin/scenarios/data-table.tsx
+++ b/apps/web/src/app/admin/scenarios/data-table.tsx
@@ -67,8 +67,8 @@ export function DataTable<TData, TValue>({
               </TableRow>
             ))
           ) : (
-            <TableRow>
-              <TableCell colSpan={columns.length} className="h-24 text-center">
+            <TableRow aria-live="polite">
+              <TableCell colSpan={columns.length} className="h-24 text-center" role="status">
                 No results.
               </TableCell>
             </TableRow>

--- a/apps/web/src/app/admin/scenarios/data-table.tsx
+++ b/apps/web/src/app/admin/scenarios/data-table.tsx
@@ -33,7 +33,7 @@ export function DataTable<TData, TValue>({
 
   return (
     <div className="rounded-md border w-full max-w-full overflow-auto">
-      <Table>
+      <Table aria-label="Scenarios data table">
         <TableHeader>
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id}>

--- a/apps/web/src/app/admin/scenarios/data-table.tsx
+++ b/apps/web/src/app/admin/scenarios/data-table.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+interface DataTableProperties<TData, TValue> {
+  columns: ColumnDef<TData, TValue>[];
+  data: TData[];
+}
+
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+}: DataTableProperties<TData, TValue>) {
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <div className="rounded-md border w-full max-w-full overflow-auto">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => {
+                return (
+                  <TableHead key={header.id}>
+                    {header.isPlaceholder
+                      ? undefined
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                );
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {table.getRowModel().rows?.length ? (
+            table.getRowModel().rows.map((row) => (
+              <TableRow
+                key={row.id}
+                data-state={row.getIsSelected() && "selected"}
+              >
+                {row.getVisibleCells().map((cell) => (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))
+          ) : (
+            <TableRow>
+              <TableCell colSpan={columns.length} className="h-24 text-center">
+                No results.
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/scenarios/data-table.tsx
+++ b/apps/web/src/app/admin/scenarios/data-table.tsx
@@ -58,6 +58,7 @@ export function DataTable<TData, TValue>({
               <TableRow
                 key={row.id}
                 data-state={row.getIsSelected() && "selected"}
+                aria-selected={row.getIsSelected()}
               >
                 {row.getVisibleCells().map((cell) => (
                   <TableCell key={cell.id}>
@@ -68,7 +69,11 @@ export function DataTable<TData, TValue>({
             ))
           ) : (
             <TableRow aria-live="polite">
-              <TableCell colSpan={columns.length} className="h-24 text-center" role="status">
+              <TableCell
+                colSpan={columns.length}
+                className="h-24 text-center"
+                role="status"
+              >
                 No results.
               </TableCell>
             </TableRow>

--- a/apps/web/src/app/admin/scenarios/edit/[id]/page.tsx
+++ b/apps/web/src/app/admin/scenarios/edit/[id]/page.tsx
@@ -23,8 +23,8 @@ export default async function Page({ params }: { params: Parameters }) {
   scenario.plan.homeAirport ??= "";
 
   return (
-    <div className="p-4">
-      <h1 className="text-xl font-bold mb-4">Edit Scenario</h1>
+    <div>
+      <h1 className="text-xl font-bold">Edit Scenario</h1>
       <Suspense fallback={<Loading />}>
         <ScenarioForm defaultValues={scenario} />
       </Suspense>

--- a/apps/web/src/app/admin/scenarios/page.tsx
+++ b/apps/web/src/app/admin/scenarios/page.tsx
@@ -8,7 +8,7 @@ export default async function Page() {
   const scenarios = result.success ? result.data : [];
 
   return (
-    <main className="flex h-full flex-col items-center justify-center text-center px-4 py-16">
+    <main className="flex h-full flex-col items-center justify-center text-center px-4">
       <h1>Scenario manager</h1>
       <DataTable columns={defaultColumns} data={scenarios} />
     </main>

--- a/apps/web/src/app/admin/scenarios/page.tsx
+++ b/apps/web/src/app/admin/scenarios/page.tsx
@@ -1,14 +1,16 @@
-"use client";
-import { Button } from "@/components/ui/button";
-import Link from "next/link";
+"use server";
+import { fetchScenarios } from "@/api/scenarios/fetch-scenarios";
+import { defaultColumns } from "./columns";
+import { DataTable } from "./data-table";
 
-export default function Page() {
+export default async function Page() {
+  const result = await fetchScenarios();
+  const scenarios = result.success ? result.data : [];
+
   return (
     <main className="flex h-full flex-col items-center justify-center text-center px-4 py-16">
-      <h3>Scenario manager</h3>
-      <Button asChild>
-        <Link href="/admin/scenarios/new">New Scenario</Link>
-      </Button>
+      <h1>Scenario manager</h1>
+      <DataTable columns={defaultColumns} data={scenarios} />
     </main>
   );
 }

--- a/apps/web/src/app/admin/scenarios/row-actions.tsx
+++ b/apps/web/src/app/admin/scenarios/row-actions.tsx
@@ -10,6 +10,7 @@ import { useDeleteScenario } from "@/hooks/use-delete-scenario";
 import { MoreHorizontal } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
+import { toast } from "sonner";
 
 type RowActionsProperties = {
   scenarioId?: string;
@@ -18,6 +19,18 @@ type RowActionsProperties = {
 export const RowActions = ({ scenarioId }: RowActionsProperties) => {
   const deleteScenario = useDeleteScenario();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  const deleteScenarioHandler = async () => {
+    toast.promise(deleteScenario(scenarioId), {
+      loading: "Deleting scenario...",
+      success: () => {
+        return "Scenario deleted successfully";
+      },
+      error: () => {
+        return "Error deleting scenario";
+      },
+    });
+  };
 
   return (
     <div>
@@ -29,7 +42,7 @@ export const RowActions = ({ scenarioId }: RowActionsProperties) => {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem asChild>
+          <DropdownMenuItem>
             <Link
               href={`/admin/scenarios/edit/${scenarioId}`}
               aria-label="Edit scenario"
@@ -49,7 +62,7 @@ export const RowActions = ({ scenarioId }: RowActionsProperties) => {
         aria-label="Delete scenario"
         isDialogOpen={isDeleteDialogOpen}
         setIsDialogOpen={setIsDeleteDialogOpen}
-        onConfirm={() => deleteScenario(scenarioId, { redirect: false })}
+        onConfirm={deleteScenarioHandler}
       />
     </div>
   );

--- a/apps/web/src/app/admin/scenarios/row-actions.tsx
+++ b/apps/web/src/app/admin/scenarios/row-actions.tsx
@@ -29,7 +29,7 @@ export const RowActions = ({ scenarioId }: RowActionsProperties) => {
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem>
+          <DropdownMenuItem asChild>
             <Link
               href={`/admin/scenarios/edit/${scenarioId}`}
               aria-label="Edit scenario"

--- a/apps/web/src/app/admin/scenarios/row-actions.tsx
+++ b/apps/web/src/app/admin/scenarios/row-actions.tsx
@@ -1,0 +1,29 @@
+import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog";
+import { Button } from "@/components/ui/button";
+import { useDeleteScenario } from "@/hooks/use-delete-scenario";
+import { Pencil } from "lucide-react";
+import Link from "next/link";
+
+type RowActionsProperties = {
+  scenarioId?: string;
+};
+
+export const RowActions = ({ scenarioId }: RowActionsProperties) => {
+  const deleteScenario = useDeleteScenario();
+
+  return (
+    <div className="flex gap-2">
+      <Link
+        href={`/admin/scenarios/edit/${scenarioId}`}
+        aria-label="Edit scenario"
+      >
+        <Button variant="outline" size="icon">
+          <Pencil className="h-4 w-4" />
+        </Button>
+      </Link>
+      <ConfirmDeleteDialog
+        onConfirm={() => deleteScenario(scenarioId, { redirect: false })}
+      />
+    </div>
+  );
+};

--- a/apps/web/src/app/admin/scenarios/row-actions.tsx
+++ b/apps/web/src/app/admin/scenarios/row-actions.tsx
@@ -1,8 +1,15 @@
 import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog";
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { useDeleteScenario } from "@/hooks/use-delete-scenario";
-import { Pencil } from "lucide-react";
+import { MoreHorizontal } from "lucide-react";
 import Link from "next/link";
+import { useState } from "react";
 
 type RowActionsProperties = {
   scenarioId?: string;
@@ -10,19 +17,38 @@ type RowActionsProperties = {
 
 export const RowActions = ({ scenarioId }: RowActionsProperties) => {
   const deleteScenario = useDeleteScenario();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   return (
-    <div className="flex gap-2">
-      <Link
-        href={`/admin/scenarios/edit/${scenarioId}`}
-        aria-label="Edit scenario"
-      >
-        <Button variant="outline" size="icon">
-          <Pencil className="h-4 w-4" />
-        </Button>
-      </Link>
+    <div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button variant="ghost" className="h-8 w-8 p-0">
+            <span className="sr-only">Open menu</span>
+            <MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem>
+            <Link
+              href={`/admin/scenarios/edit/${scenarioId}`}
+              aria-label="Edit scenario"
+            >
+              Edit
+            </Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="destructive"
+            onClick={() => setIsDeleteDialogOpen(true)}
+          >
+            Delete
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       <ConfirmDeleteDialog
         aria-label="Delete scenario"
+        isDialogOpen={isDeleteDialogOpen}
+        setIsDialogOpen={setIsDeleteDialogOpen}
         onConfirm={() => deleteScenario(scenarioId, { redirect: false })}
       />
     </div>

--- a/apps/web/src/app/admin/scenarios/row-actions.tsx
+++ b/apps/web/src/app/admin/scenarios/row-actions.tsx
@@ -22,6 +22,7 @@ export const RowActions = ({ scenarioId }: RowActionsProperties) => {
         </Button>
       </Link>
       <ConfirmDeleteDialog
+        aria-label="Delete scenario"
         onConfirm={() => deleteScenario(scenarioId, { redirect: false })}
       />
     </div>

--- a/apps/web/src/app/lab/[id]/client-section.tsx
+++ b/apps/web/src/app/lab/[id]/client-section.tsx
@@ -7,7 +7,9 @@ import { Button } from "@/components/ui/button";
 import { useDeleteScenario } from "@/hooks/use-delete-scenario";
 import { Scenario } from "@workspace/validators";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { toast } from "sonner";
 
 interface ClientSectionProperties {
   scenario: Scenario;
@@ -18,8 +20,22 @@ export default function ClientSection({
   scenario,
   canEdit,
 }: ClientSectionProperties) {
-  const onDelete = useDeleteScenario();
+  const deleteScenario = useDeleteScenario();
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const router = useRouter();
+
+  const deleteScenarioHandler = async () => {
+    toast.promise(deleteScenario(scenario._id), {
+      loading: "Deleting scenario...",
+      success: () => {
+        router.replace("/lab");
+        return "Scenario deleted successfully";
+      },
+      error: () => {
+        return "Error deleting scenario";
+      },
+    });
+  };
 
   return (
     <main className="p-6 overflow-y-auto">
@@ -35,7 +51,7 @@ export default function ClientSection({
             Delete
           </Button>
           <ConfirmDeleteDialog
-            onConfirm={() => onDelete(scenario._id)}
+            onConfirm={deleteScenarioHandler}
             isDialogOpen={isDeleteDialogOpen}
             setIsDialogOpen={setIsDeleteDialogOpen}
           />

--- a/apps/web/src/app/lab/[id]/client-section.tsx
+++ b/apps/web/src/app/lab/[id]/client-section.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { useDeleteScenario } from "@/hooks/use-delete-scenario";
 import { Scenario } from "@workspace/validators";
 import Link from "next/link";
+import { useState } from "react";
 
 interface ClientSectionProperties {
   scenario: Scenario;
@@ -18,6 +19,7 @@ export default function ClientSection({
   canEdit,
 }: ClientSectionProperties) {
   const onDelete = useDeleteScenario();
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
   return (
     <main className="p-6 overflow-y-auto">
@@ -26,13 +28,16 @@ export default function ClientSection({
           <Button asChild>
             <Link href={`/admin/scenarios/edit/${scenario._id}`}>Edit</Link>
           </Button>
+          <Button
+            variant="destructive"
+            onClick={() => setIsDeleteDialogOpen(true)}
+          >
+            Delete
+          </Button>
           <ConfirmDeleteDialog
             onConfirm={() => onDelete(scenario._id)}
-            trigger={
-              <Button variant="destructive" aria-label="Delete scenario">
-                Delete
-              </Button>
-            }
+            isDialogOpen={isDeleteDialogOpen}
+            setIsDialogOpen={setIsDeleteDialogOpen}
           />
         </div>
       )}

--- a/apps/web/src/app/lab/[id]/client-section.tsx
+++ b/apps/web/src/app/lab/[id]/client-section.tsx
@@ -1,24 +1,12 @@
 "use client";
 
-import { deleteScenario } from "@/api/scenarios/delete-scenario";
 import { Answer } from "@/components/answer";
+import { ConfirmDeleteDialog } from "@/components/confirm-delete-dialog";
 import FPE from "@/components/fpe/fpe";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { useDeleteScenario } from "@/hooks/use-delete-scenario";
 import { Scenario } from "@workspace/validators";
 import Link from "next/link";
-import { useRouter } from "next/navigation"; // App Router
-import { toast } from "sonner";
 
 interface ClientSectionProperties {
   scenario: Scenario;
@@ -29,22 +17,7 @@ export default function ClientSection({
   scenario,
   canEdit,
 }: ClientSectionProperties) {
-  const router = useRouter();
-
-  const onDeleteScenario = async () => {
-    if (!scenario._id) {
-      console.error("Scenario ID is missing");
-      return;
-    }
-
-    const result = await deleteScenario(scenario._id);
-
-    if (result) {
-      router.replace("/lab");
-    } else {
-      toast.error("Unable to delete scenario.");
-    }
-  };
+  const onDelete = useDeleteScenario();
 
   return (
     <main className="p-6 overflow-y-auto">
@@ -53,32 +26,14 @@ export default function ClientSection({
           <Button asChild>
             <Link href={`/admin/scenarios/edit/${scenario._id}`}>Edit</Link>
           </Button>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="destructive">Delete</Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This action cannot be undone. This will permanently delete the
-                  scenario.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction asChild>
-                  <Button
-                    onClick={onDeleteScenario}
-                    variant="destructive"
-                    aria-label="Delete scenario"
-                  >
-                    Delete
-                  </Button>
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
+          <ConfirmDeleteDialog
+            onConfirm={() => onDelete(scenario._id)}
+            trigger={
+              <Button variant="destructive" aria-label="Delete scenario">
+                Delete
+              </Button>
+            }
+          />
         </div>
       )}
       <FPE scenario={scenario} />

--- a/apps/web/src/components/confirm-delete-dialog.tsx
+++ b/apps/web/src/components/confirm-delete-dialog.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Trash } from "lucide-react";
+
+type ConfirmDeleteDialogProperties = {
+  onConfirm: () => void;
+  trigger?: React.ReactNode;
+  title?: string;
+  description?: string;
+};
+
+export const ConfirmDeleteDialog = ({
+  onConfirm,
+  trigger,
+  title = "Are you absolutely sure?",
+  description = "This action cannot be undone. This will permanently delete the item.",
+}: ConfirmDeleteDialogProperties) => {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        {trigger ?? (
+          <Button variant="destructive" size="icon" aria-label="Delete">
+            <Trash className="h-4 w-4" />
+          </Button>
+        )}
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction asChild>
+            <button
+              type="button"
+              onClick={onConfirm}
+              className="bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60"
+              aria-label="Confirm delete"
+            >
+              Delete
+            </button>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/apps/web/src/components/confirm-delete-dialog.tsx
+++ b/apps/web/src/components/confirm-delete-dialog.tsx
@@ -9,33 +9,26 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
-import { Trash } from "lucide-react";
 
 type ConfirmDeleteDialogProperties = {
   onConfirm: () => void;
   trigger?: React.ReactNode;
   title?: string;
   description?: string;
+  isDialogOpen: boolean;
+  setIsDialogOpen: (isOpen: boolean) => void;
 };
 
 export const ConfirmDeleteDialog = ({
   onConfirm,
-  trigger,
   title = "Are you absolutely sure?",
   description = "This action cannot be undone. This will permanently delete the item.",
+  isDialogOpen,
+  setIsDialogOpen,
 }: ConfirmDeleteDialogProperties) => {
   return (
-    <AlertDialog>
-      <AlertDialogTrigger asChild>
-        {trigger ?? (
-          <Button variant="destructive" size="icon" aria-label="Delete">
-            <Trash className="h-4 w-4" />
-          </Button>
-        )}
-      </AlertDialogTrigger>
+    <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>{title}</AlertDialogTitle>

--- a/apps/web/src/components/scenario-form/scenario-form.tsx
+++ b/apps/web/src/components/scenario-form/scenario-form.tsx
@@ -54,7 +54,7 @@ export const ScenarioForm = ({
     }
 
     const message = (
-      <div>
+      <div className="py-4">
         Scenario {isEditMode ? "updated" : "saved"}!
         {formState.id && (
           <>

--- a/apps/web/src/hooks/use-delete-scenario.tsx
+++ b/apps/web/src/hooks/use-delete-scenario.tsx
@@ -20,8 +20,10 @@ export const useDeleteScenario = () => {
     const result = await deleteScenario(scenarioId);
 
     if (result) {
-      if (options.redirect !== false) {
+      if (options.redirect) {
         router.replace("/lab");
+      } else {
+        toast.success("Scenario deleted successfully.");
       }
     } else {
       toast.error("Unable to delete scenario.");

--- a/apps/web/src/hooks/use-delete-scenario.tsx
+++ b/apps/web/src/hooks/use-delete-scenario.tsx
@@ -1,32 +1,18 @@
 "use client";
 
 import { deleteScenario } from "@/api/scenarios/delete-scenario";
-import { useRouter } from "next/navigation";
-import { toast } from "sonner";
-
-type Options = {
-  redirect?: boolean;
-};
 
 export const useDeleteScenario = () => {
-  const router = useRouter();
-
-  return async (scenarioId: string | undefined, options: Options = {}) => {
+  return async (scenarioId: string | undefined) => {
     if (!scenarioId) {
       console.error("Scenario ID is missing");
       return;
     }
 
-    const result = await deleteScenario(scenarioId);
-
-    if (result) {
-      if (options.redirect) {
-        router.replace("/lab");
-      } else {
-        toast.success("Scenario deleted successfully.");
-      }
-    } else {
-      toast.error("Unable to delete scenario.");
+    try {
+      const result = await deleteScenario(scenarioId);
+    } catch (error) {
+      console.error(`Failed to delete scenario: ${error}`);
     }
   };
 };

--- a/apps/web/src/hooks/use-delete-scenario.tsx
+++ b/apps/web/src/hooks/use-delete-scenario.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { deleteScenario } from "@/api/scenarios/delete-scenario";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+
+type Options = {
+  redirect?: boolean;
+};
+
+export const useDeleteScenario = () => {
+  const router = useRouter();
+
+  return async (scenarioId: string | undefined, options: Options = {}) => {
+    if (!scenarioId) {
+      console.error("Scenario ID is missing");
+      return;
+    }
+
+    const result = await deleteScenario(scenarioId);
+
+    if (result) {
+      if (options.redirect !== false) {
+        router.replace("/lab");
+      }
+    } else {
+      toast.error("Unable to delete scenario.");
+    }
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.0
         version: 1.2.4(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@workspace/plantools':
         specifier: workspace:*
         version: link:../../packages/plantools
@@ -2975,6 +2978,17 @@ packages:
 
   '@tailwindcss/postcss@4.1.5':
     resolution: {integrity: sha512-5lAC2/pzuyfhsFgk6I58HcNy6vPK3dV/PoPxSDuOTVbDvCddYHzHiJZZInGIY0venvzzfrTEUAXJFULAfFmObg==}
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
@@ -10002,6 +10016,14 @@ snapshots:
       postcss: 8.5.3
       tailwindcss: 4.1.5
 
+  '@tanstack/react-table@8.21.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@tanstack/table-core@8.21.3': {}
+
   '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@ts-morph/common@0.19.0':
@@ -11172,7 +11194,7 @@ snapshots:
       '@typescript-eslint/parser': 8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.0)(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.26.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.26.0(jiti@2.4.2))
@@ -11196,7 +11218,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -11211,14 +11233,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@9.26.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.0(eslint-plugin-import@2.31.0)(eslint@9.26.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -11233,7 +11255,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.26.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2)))(eslint@9.26.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.31.1(eslint@9.26.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@9.26.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Fixes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a reusable confirmation dialog component for delete actions.
  - Added a data table for displaying scenarios in the admin interface, with sortable columns and row actions.
  - Added row action buttons for editing and deleting scenarios directly from the table.

- **Refactor**
  - Centralized and abstracted scenario deletion logic using a custom hook and the new confirmation dialog component.
  - Shifted scenario data fetching to the server for improved performance and simplified the admin scenarios page layout.

- **Bug Fixes**
  - Improved error handling for scenario fetching by returning structured failure responses instead of throwing errors.

- **Chores**
  - Added the `@tanstack/react-table` package as a new dependency.
  - Updated debug configuration to use a new server URL path for admin scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->