### PR TITLE
Add a loading state to the scenarios table page

### DIFF
--- a/apps/web/src/app/admin/scenarios/client-section.tsx
+++ b/apps/web/src/app/admin/scenarios/client-section.tsx
@@ -1,0 +1,15 @@
+import { Scenario } from "@workspace/validators";
+import { defaultColumns } from "./columns";
+import { DataTable } from "./data-table";
+
+interface ClientSectionProperties {
+  scenarios: Scenario[];
+}
+
+export default function ClientSection({ scenarios }: ClientSectionProperties) {
+  return (
+    <div>
+      <DataTable columns={defaultColumns} data={scenarios} />
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/scenarios/client-section.tsx
+++ b/apps/web/src/app/admin/scenarios/client-section.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import { Scenario } from "@workspace/validators";
-import { defaultColumns } from "./columns";
+import { getScenarioColumns } from "./columns";
 import { DataTable } from "./data-table";
 
 interface ClientSectionProperties {
@@ -9,7 +11,7 @@ interface ClientSectionProperties {
 export default function ClientSection({ scenarios }: ClientSectionProperties) {
   return (
     <div>
-      <DataTable columns={defaultColumns} data={scenarios} />
+      <DataTable columns={getScenarioColumns()} data={scenarios} />
     </div>
   );
 }

--- a/apps/web/src/app/admin/scenarios/client-section.tsx
+++ b/apps/web/src/app/admin/scenarios/client-section.tsx
@@ -10,7 +10,7 @@ interface ClientSectionProperties {
 
 export default function ClientSection({ scenarios }: ClientSectionProperties) {
   return (
-    <div>
+    <div aria-label="Scenarios table container">
       <DataTable columns={getScenarioColumns()} data={scenarios} />
     </div>
   );

--- a/apps/web/src/app/admin/scenarios/columns.tsx
+++ b/apps/web/src/app/admin/scenarios/columns.tsx
@@ -1,3 +1,4 @@
+// components/columns.tsx
 "use client";
 
 import { YesNoIcon } from "@/components/yes-no-icon";
@@ -5,92 +6,66 @@ import { createColumnHelper, type ColumnDef } from "@tanstack/react-table";
 import { Scenario } from "@workspace/validators";
 import { RowActions } from "./row-actions";
 
-const columnHelper = createColumnHelper<Scenario>();
+export function getScenarioColumns(): ColumnDef<Scenario>[] {
+  const columnHelper = createColumnHelper<Scenario>();
 
-const columns = [
-  columnHelper.accessor("plan.aid", {
-    id: "plan.aid",
-    header: () => (
-      <div aria-sort="none" className="uppercase">
-        Callsign
-      </div>
-    ),
-    cell: (info) => <div>{info.getValue()}</div>,
-    enableSorting: false,
-    enableHiding: false,
-  }),
-  columnHelper.accessor("plan.dep", {
-    id: "plan.dep",
-    header: () => (
-      <div aria-sort="none" className="uppercase">
-        Departure
-      </div>
-    ),
-    cell: (info) => <div>{info.getValue()}</div>,
-    enableSorting: false,
-    enableHiding: false,
-  }),
-  columnHelper.accessor("plan.dest", {
-    id: "plan.dest",
-    header: () => (
-      <div aria-sort="none" className="uppercase">
-        Arrival
-      </div>
-    ),
-    cell: (info) => <div>{info.getValue()}</div>,
-    enableSorting: false,
-    enableHiding: false,
-  }),
-  columnHelper.accessor("plan.rte", {
-    id: "plan.rte",
-    header: () => (
-      <div className="text-left uppercase" aria-sort="none">
-        Route
-      </div>
-    ),
-    cell: (info) => (
-      <div className="text-left whitespace-normal">{info.getValue()}</div>
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  }),
-  columnHelper.accessor("isValid", {
-    id: "isValid",
-    header: () => (
-      <div className="text-left uppercase" aria-sort="none">
-        Is valid
-      </div>
-    ),
-    cell: (info) => (
-      <div className="flex justify-center items-center">
-        <YesNoIcon value={info.getValue()} />
-      </div>
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  }),
-  columnHelper.accessor("canClear", {
-    id: "canClear",
-    header: () => (
-      <div className="text-left uppercase" aria-sort="none">
-        Can clear
-      </div>
-    ),
-    cell: (info) => (
-      <div className="flex justify-center items-center">
-        <YesNoIcon value={info.getValue()} />
-      </div>
-    ),
-    enableSorting: false,
-    enableHiding: false,
-  }),
-  columnHelper.display({
-    id: "actions",
-    cell: ({ row }) => {
-      const scenario = row.original;
-      return <RowActions scenarioId={scenario._id} />;
-    },
-  }),
-] as ColumnDef<Scenario>[];
-
-export const defaultColumns = columns;
+  return [
+    columnHelper.accessor("plan.aid", {
+      id: "plan.aid",
+      header: () => <div className="uppercase">Callsign</div>,
+      cell: (info) => <div>{info.getValue()}</div>,
+      minSize: 100,
+      enableSorting: false,
+      enableHiding: false,
+    }),
+    columnHelper.accessor("plan.dep", {
+      id: "plan.dep",
+      header: () => <div className="uppercase">Departure</div>,
+      cell: (info) => <div>{info.getValue()}</div>,
+      enableSorting: false,
+      enableHiding: false,
+    }),
+    columnHelper.accessor("plan.dest", {
+      id: "plan.dest",
+      header: () => <div className="uppercase">Arrival</div>,
+      cell: (info) => <div>{info.getValue()}</div>,
+      enableSorting: false,
+      enableHiding: false,
+    }),
+    columnHelper.accessor("plan.rte", {
+      id: "plan.rte",
+      header: () => <div className="text-left uppercase">Route</div>,
+      cell: (info) => (
+        <div className="text-left whitespace-normal">{info.getValue()}</div>
+      ),
+      enableSorting: false,
+      enableHiding: false,
+    }),
+    columnHelper.accessor("isValid", {
+      id: "isValid",
+      header: () => <div className="text-left uppercase">Is valid</div>,
+      cell: (info) => (
+        <div className="flex justify-center items-center">
+          <YesNoIcon value={info.getValue()} />
+        </div>
+      ),
+      enableSorting: false,
+      enableHiding: false,
+    }),
+    columnHelper.accessor("canClear", {
+      id: "canClear",
+      header: () => <div className="text-left uppercase">Can clear</div>,
+      cell: (info) => (
+        <div className="flex justify-center items-center">
+          <YesNoIcon value={info.getValue()} />
+        </div>
+      ),
+      enableSorting: false,
+      enableHiding: false,
+    }),
+    columnHelper.display({
+      id: "actions",
+      cell: ({ row }) => <RowActions scenarioId={row.original._id} />,
+    }),
+  ] as ColumnDef<Scenario>[];
+}

--- a/apps/web/src/app/admin/scenarios/loading.tsx
+++ b/apps/web/src/app/admin/scenarios/loading.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { SiteHeader } from "@/components/site-header";
+import { Spinner } from "@/components/ui/spinner";
+
+export default function Loading() {
+  return (
+    <div>
+      <SiteHeader />
+      <main
+        className="flex min-h-screen flex-col items-center justify-center text-center px-4 py-4"
+        aria-label="Loading scenarios"
+      >
+        <Spinner size="medium">
+          <span>Loading scenarios...</span>
+        </Spinner>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/scenarios/page.tsx
+++ b/apps/web/src/app/admin/scenarios/page.tsx
@@ -1,8 +1,7 @@
 "use server";
 import { fetchScenarios } from "@/api/scenarios/fetch-scenarios";
 import { SiteHeader } from "@/components/site-header";
-import { defaultColumns } from "./columns";
-import { DataTable } from "./data-table";
+import ClientSection from "./client-section";
 
 export default async function Page() {
   const result = await fetchScenarios();
@@ -15,7 +14,7 @@ export default async function Page() {
         className="flex h-full flex-col items-center justify-center text-center px-4 py-4"
         aria-label="Scenarios management"
       >
-        <DataTable columns={defaultColumns} data={scenarios} />
+        <ClientSection scenarios={scenarios} />
       </main>
     </div>
   );

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/lib/utils";
+import { VariantProps, cva } from "class-variance-authority";
+import { Loader2 } from "lucide-react";
+import React from "react";
+
+const spinnerVariants = cva("flex-col items-center justify-center", {
+  variants: {
+    show: {
+      true: "flex",
+      false: "hidden",
+    },
+  },
+  defaultVariants: {
+    show: true,
+  },
+});
+
+const loaderVariants = cva("animate-spin text-primary", {
+  variants: {
+    size: {
+      small: "size-6",
+      medium: "size-8",
+      large: "size-12",
+    },
+  },
+  defaultVariants: {
+    size: "medium",
+  },
+});
+
+interface SpinnerContentProps
+  extends VariantProps<typeof spinnerVariants>,
+    VariantProps<typeof loaderVariants> {
+  className?: string;
+  children?: React.ReactNode;
+}
+
+export function Spinner({
+  size,
+  show,
+  children,
+  className,
+}: SpinnerContentProps) {
+  return (
+    <span className={spinnerVariants({ show })}>
+      <Loader2 className={cn(loaderVariants({ size }), className)} />
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
Fixes #364 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a loading screen with a spinner and header for the scenarios section.
  - Added a new client-side section to display scenario data in a table format.

- **Refactor**
  - Updated the scenarios page to use the new client-side section for displaying data.
  - Refactored scenario table columns into a reusable function for improved flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->