### PR TITLE
Handle empty telephony values in CRAFT

### DIFF
--- a/packages/plantools/src/formatting.ts
+++ b/packages/plantools/src/formatting.ts
@@ -42,7 +42,11 @@ export const capitalizeFirst = (value: string) =>
  * @returns The CRAFT telephony, or the flight callsign if not available
  */
 export const getTelephony = (scenario: Scenario) => {
-  return scenario.craft?.telephony ?? scenario.plan.aid;
+  // Using || here is intentional to get a falsy check on empty strings.
+  // Using ?? won't work since empty strings aren't null or undefined.
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const result = scenario.craft?.telephony?.trim() || scenario.plan.aid;
+  return result;
 };
 
 /**


### PR DESCRIPTION
Fixes #370

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty telephony values to ensure fallback values are used when appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->