### PR TITLE
AUTH0_DOMAIN is *not* an URL

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,10 +77,10 @@ Auth0 is disabled by default. To enable it, create a file called `devcontainer.e
 
 For Auth0 to work on the API server, the following variables must be set, either via a `.env.local` file in the `apps/api` folder or in the `devcontainer.env.overrides` file:
 
-| Variable         | Description                                     |
-| ---------------- | ----------------------------------------------- |
-| `AUTH0_DOMAIN`   | Domain of the Auth0 Clearance Lab application.  |
-| `AUTH0_AUDIENCE` | URL for the API created in the Auth0 dashboard. |
+| Variable         | Description                                                                                                                |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH0_DOMAIN`   | Domain of the Auth0 Clearance Lab application. This is not an URL. Copy the value exactly as shown in the AUTH0 dashboard. |
+| `AUTH0_AUDIENCE` | URL for the API created in the Auth0 dashboard.                                                                            |
 
 There are additional security-related variables to configure CORS and rate-limiting:
 
@@ -92,13 +92,13 @@ There are additional security-related variables to configure CORS and rate-limit
 
 The web app also needs several Auth0 variables set to validate secured endpoints. These are only required if you want to test authentication locally (when `DISABLE_AUTH` is set to `false`). These can be set in the `devcontainer.env.overrides` file or in a `.env.local` file in the `apps/web` folder.
 
-| Variable              | Description                                                                                         |
-| --------------------- | --------------------------------------------------------------------------------------------------- |
-| `AUTH0_AUDIENCE`      | URL for the API created in the Auth0 dashboard.                                                     |
-| `AUTH0_CLIENT_ID`     | Client ID of the Clearance Lab application in Auth0.                                                |
-| `AUTH0_CLIENT_SECRET` | Client-side secret for Auth0.                                                                       |
-| `AUTH0_DOMAIN`        | Domain of the Clearance Lab application in Auth0. This must be a valid URI and start with https://. |
-| `AUTH0_SECRET`        | Secret for the Clearance Lab application in Auth0.                                                  |
+| Variable              | Description                                                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH0_AUDIENCE`      | URL for the API created in the Auth0 dashboard.                                                                               |
+| `AUTH0_CLIENT_ID`     | Client ID of the Clearance Lab application in Auth0.                                                                          |
+| `AUTH0_CLIENT_SECRET` | Client-side secret for Auth0.                                                                                                 |
+| `AUTH0_DOMAIN`        | Domain of the Clearance Lab application in Auth0. This is not an URL. Copy the value exactly as shown in the AUTH0 dashboard. |
+| `AUTH0_SECRET`        | Secret for the Clearance Lab application in Auth0.                                                                            |
 
 To speed builds, the following environment variables can be set to enable TurboRepo remote caching:
 
@@ -123,17 +123,17 @@ The API server supports the following variables:
 
 The web UI deploys as a Cloudflare worker via the [GitHub release workflow](#deployment). The following variables and secrets are supported:
 
-| Variable              | Description                                                                                         | Required |
-| --------------------- | --------------------------------------------------------------------------------------------------- | -------- |
-| `API_BASE_URL`        | URI to the API server.                                                                              | ✅       |
-| `API_KEY`             | API key for access to the API server.                                                               | ✅       |
-| `APP_BASE_URL`        | URI to the web app.                                                                                 | ✅       |
-| `AUTH0_AUDIENCE`      | URL for the API created in the Auth0 dashboard.                                                     | ✅       |
-| `AUTH0_CLIENT_ID`     | Client ID of the Clearance Lab application in Auth0.                                                | ✅       |
-| `AUTH0_CLIENT_SECRET` | Client-side secret for Auth0.                                                                       | ✅       |
-| `AUTH0_DOMAIN`        | Domain of the Clearance Lab application in Auth0. This must be a valid URI and start with https://. | ✅       |
-| `AUTH0_SECRET`        | Secret for the Clearance Lab application in Auth0.                                                  | ✅       |
-| `DEPLOY_ENV`          | Deployment environment, either `prod` or `dev`.                                                     | ✅       |
+| Variable              | Description                                                                                                                   | Required |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `API_BASE_URL`        | URI to the API server.                                                                                                        | ✅       |
+| `API_KEY`             | API key for access to the API server.                                                                                         | ✅       |
+| `APP_BASE_URL`        | URI to the web app.                                                                                                           | ✅       |
+| `AUTH0_AUDIENCE`      | URL for the API created in the Auth0 dashboard.                                                                               | ✅       |
+| `AUTH0_CLIENT_ID`     | Client ID of the Clearance Lab application in Auth0.                                                                          | ✅       |
+| `AUTH0_CLIENT_SECRET` | Client-side secret for Auth0.                                                                                                 | ✅       |
+| `AUTH0_DOMAIN`        | Domain of the Clearance Lab application in Auth0. This is not an URL. Copy the value exactly as shown in the AUTH0 dashboard. | ✅       |
+| `AUTH0_SECRET`        | Secret for the Clearance Lab application in Auth0.                                                                            | ✅       |
+| `DEPLOY_ENV`          | Deployment environment, either `prod` or `dev`.                                                                               | ✅       |
 
 The environment variables are set in the [`wrangler.toml`](apps/web/wrangler.toml) file and in GitHub environment variables. They must be set in both places, so the CI builds will pass environment variable verification.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,10 +77,10 @@ Auth0 is disabled by default. To enable it, create a file called `devcontainer.e
 
 For Auth0 to work on the API server, the following variables must be set, either via a `.env.local` file in the `apps/api` folder or in the `devcontainer.env.overrides` file:
 
-| Variable         | Description                                                                                                                |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `AUTH0_DOMAIN`   | Domain of the Auth0 Clearance Lab application. This is not an URL. Copy the value exactly as shown in the AUTH0 dashboard. |
-| `AUTH0_AUDIENCE` | URL for the API created in the Auth0 dashboard.                                                                            |
+| Variable         | Description                                                                                                               |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH0_DOMAIN`   | Domain of the Auth0 Clearance Lab application. This is not a URL. Copy the value exactly as shown in the AUTH0 dashboard. |
+| `AUTH0_AUDIENCE` | URL for the API created in the Auth0 dashboard.                                                                           |
 
 There are additional security-related variables to configure CORS and rate-limiting:
 
@@ -92,13 +92,13 @@ There are additional security-related variables to configure CORS and rate-limit
 
 The web app also needs several Auth0 variables set to validate secured endpoints. These are only required if you want to test authentication locally (when `DISABLE_AUTH` is set to `false`). These can be set in the `devcontainer.env.overrides` file or in a `.env.local` file in the `apps/web` folder.
 
-| Variable              | Description                                                                                                                   |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `AUTH0_AUDIENCE`      | URL for the API created in the Auth0 dashboard.                                                                               |
-| `AUTH0_CLIENT_ID`     | Client ID of the Clearance Lab application in Auth0.                                                                          |
-| `AUTH0_CLIENT_SECRET` | Client-side secret for Auth0.                                                                                                 |
-| `AUTH0_DOMAIN`        | Domain of the Clearance Lab application in Auth0. This is not an URL. Copy the value exactly as shown in the AUTH0 dashboard. |
-| `AUTH0_SECRET`        | Secret for the Clearance Lab application in Auth0.                                                                            |
+| Variable              | Description                                                                                                                  |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH0_AUDIENCE`      | URL for the API created in the Auth0 dashboard.                                                                              |
+| `AUTH0_CLIENT_ID`     | Client ID of the Clearance Lab application in Auth0.                                                                         |
+| `AUTH0_CLIENT_SECRET` | Client-side secret for Auth0.                                                                                                |
+| `AUTH0_DOMAIN`        | Domain of the Clearance Lab application in Auth0. This is not a URL. Copy the value exactly as shown in the AUTH0 dashboard. |
+| `AUTH0_SECRET`        | Secret for the Clearance Lab application in Auth0.                                                                           |
 
 To speed builds, the following environment variables can be set to enable TurboRepo remote caching:
 
@@ -123,17 +123,17 @@ The API server supports the following variables:
 
 The web UI deploys as a Cloudflare worker via the [GitHub release workflow](#deployment). The following variables and secrets are supported:
 
-| Variable              | Description                                                                                                                   | Required |
-| --------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `API_BASE_URL`        | URI to the API server.                                                                                                        | ✅       |
-| `API_KEY`             | API key for access to the API server.                                                                                         | ✅       |
-| `APP_BASE_URL`        | URI to the web app.                                                                                                           | ✅       |
-| `AUTH0_AUDIENCE`      | URL for the API created in the Auth0 dashboard.                                                                               | ✅       |
-| `AUTH0_CLIENT_ID`     | Client ID of the Clearance Lab application in Auth0.                                                                          | ✅       |
-| `AUTH0_CLIENT_SECRET` | Client-side secret for Auth0.                                                                                                 | ✅       |
-| `AUTH0_DOMAIN`        | Domain of the Clearance Lab application in Auth0. This is not an URL. Copy the value exactly as shown in the AUTH0 dashboard. | ✅       |
-| `AUTH0_SECRET`        | Secret for the Clearance Lab application in Auth0.                                                                            | ✅       |
-| `DEPLOY_ENV`          | Deployment environment, either `prod` or `dev`.                                                                               | ✅       |
+| Variable              | Description                                                                                                                  | Required |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------- |
+| `API_BASE_URL`        | URI to the API server.                                                                                                       | ✅       |
+| `API_KEY`             | API key for access to the API server.                                                                                        | ✅       |
+| `APP_BASE_URL`        | URI to the web app.                                                                                                          | ✅       |
+| `AUTH0_AUDIENCE`      | URL for the API created in the Auth0 dashboard.                                                                              | ✅       |
+| `AUTH0_CLIENT_ID`     | Client ID of the Clearance Lab application in Auth0.                                                                         | ✅       |
+| `AUTH0_CLIENT_SECRET` | Client-side secret for Auth0.                                                                                                | ✅       |
+| `AUTH0_DOMAIN`        | Domain of the Clearance Lab application in Auth0. This is not a URL. Copy the value exactly as shown in the AUTH0 dashboard. | ✅       |
+| `AUTH0_SECRET`        | Secret for the Clearance Lab application in Auth0.                                                                           | ✅       |
+| `DEPLOY_ENV`          | Deployment environment, either `prod` or `dev`.                                                                              | ✅       |
 
 The environment variables are set in the [`wrangler.toml`](apps/web/wrangler.toml) file and in GitHub environment variables. They must be set in both places, so the CI builds will pass environment variable verification.
 

--- a/apps/api/src/lib/environment.ts
+++ b/apps/api/src/lib/environment.ts
@@ -15,7 +15,10 @@ const environmentSchema = z
       .optional(),
     AUTH0_DOMAIN: z
       .string()
-      .url({ message: "AUTH0_DOMAIN must be a valid URL." })
+      .refine((value) => !value.startsWith("https://"), {
+        message:
+          "AUTH0_DOMAIN should not be an URL. Use the value exactly as shown in the Auth0 dashboard.",
+      })
       .optional(),
     DISABLE_AUTH: z
       .preprocess((value) => value === "true" || value === "1", z.boolean())

--- a/apps/web/src/lib/environment.ts
+++ b/apps/web/src/lib/environment.ts
@@ -28,7 +28,10 @@ const environmentSchema = z
     AUTH0_CLIENT_ID: z.string().optional(),
     AUTH0_DOMAIN: z
       .string()
-      .url({ message: "AUTH0_DOMAIN must be a valid URL." })
+      .refine((value) => !value.startsWith("https://"), {
+        message:
+          "AUTH0_DOMAIN should not be an URL. Use the value exactly as shown in the Auth0 dashboard.",
+      })
       .optional(),
     AUTH0_SECRET: z.string().optional(),
     APP_BASE_URL: z

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -45,7 +45,7 @@
       "route": "clearancelab-dev.badcasserole.com/*",
       "vars": {
         "API_BASE_URL": "https://clearancelab-backend-dev.badcasserole.com",
-        "AUTH0_DOMAIN": "https://dev-q5itijfspt3smgyw.us.auth0.com",
+        "AUTH0_DOMAIN": "dev-q5itijfspt3smgyw.us.auth0.com",
         "AUTH0_CLIENT_ID": "gNF8uPUI7CFt7xfZNavjebXgtKnfXM3Z",
         "APP_BASE_URL": "https://clearancelab-dev.badcasserole.com",
         "AUTH0_AUDIENCE": "https://planverifier.badcasserole.com:4001/",
@@ -88,7 +88,7 @@
       "route": "clearancelab.badcasserole.com/*",
       "vars": {
         "API_BASE_URL": "https://clearancelab-backend.badcasserole.com",
-        "AUTH0_DOMAIN": "https://vatsim-edct.us.auth0.com/",
+        "AUTH0_DOMAIN": "vatsim-edct.us.auth0.com/",
         "AUTH0_CLIENT_ID": "HW1L8KjMG1ezy4NXxlAeNheIByjOUXcx",
         "APP_BASE_URL": "https://clearancelab.badcasserole.com",
         "AUTH0_AUDIENCE": "https://clearancelab-backend.badcasserole.com/",

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -88,7 +88,7 @@
       "route": "clearancelab.badcasserole.com/*",
       "vars": {
         "API_BASE_URL": "https://clearancelab-backend.badcasserole.com",
-        "AUTH0_DOMAIN": "vatsim-edct.us.auth0.com/",
+        "AUTH0_DOMAIN": "vatsim-edct.us.auth0.com",
         "AUTH0_CLIENT_ID": "HW1L8KjMG1ezy4NXxlAeNheIByjOUXcx",
         "APP_BASE_URL": "https://clearancelab.badcasserole.com",
         "AUTH0_AUDIENCE": "https://clearancelab-backend.badcasserole.com/",


### PR DESCRIPTION
Fixes #380

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified instructions for setting the `AUTH0_DOMAIN` environment variable, specifying that it should not include "https://" and should match the value from the Auth0 dashboard.

- **Bug Fixes**
  - Updated environment variable validation to prevent use of URLs for `AUTH0_DOMAIN` and require the correct domain format.
  - Adjusted configuration files to remove "https://" from `AUTH0_DOMAIN` values in all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->