### PR TITLE
Trigger container deployment with Watchtower webhook

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: joelwmale/webhook-action@master
         with:
           url: ${{ vars.WATCHTOWER_WEBHOOK_URL }}
-          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_TOKEN }}"}'
+          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_API_KEY }}"}'
 
   cloudflare:
     name: Deploy to Cloudflare

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -35,7 +35,7 @@ jobs:
         uses: joelwmale/webhook-action@2.4.1
         with:
           url: ${{ vars.WATCHTOWER_WEBHOOK_URL }}
-          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_API_KEY }}"}'
+          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ vars.WATCHTOWER_API_KEY }}"}'
 
   cloudflare:
     name: Deploy to Cloudflare

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -35,7 +35,7 @@ jobs:
         run: |
           curl -X POST "${{ vars.WATCHTOWER_WEBHOOK_URL}}" \
           -f --show-error \
-          -H "Authorization: Bearer ${{ vars.WATCHTOWER_API_KEY }}" \
+          -H "Authorization: Bearer ${{ secrets.WATCHTOWER_API_KEY }}" \
           -H "CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}" \
           -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"
 

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -32,7 +32,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy image
-        uses: joelwmale/webhook-action@master
+        uses: joelwmale/webhook-action@2.4.1
         with:
           url: ${{ vars.WATCHTOWER_WEBHOOK_URL }}
           headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_API_KEY }}"}'

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Deploy image
         uses: sozo-design/curl@v1.0.2
         with:
-          args: '-X POST ${{ vars.WATCHTOWER_WEBHOOK_URL}} -H "Authorization: Bearer ${{ vars.WATCHTOWER_API_KEY }}" -H "CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}" -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"'
+          args: -X GET "${{ vars.WATCHTOWER_WEBHOOK_URL}}" -H "Authorization: Bearer ${{ vars.WATCHTOWER_API_KEY }}" -H "CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}" -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"
 
   cloudflare:
     name: Deploy to Cloudflare

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -31,6 +31,12 @@ jobs:
           turbo_team: ${{ vars.TURBO_TEAM }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Deploy image
+        uses: joelwmale/webhook-action@master
+        with:
+          url: ${{ vars.WATCHTOWER_WEBHOOK_URL }}
+          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_TOKEN }}"}'
+
   cloudflare:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -32,10 +32,9 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy image
-        uses: joelwmale/webhook-action@2.4.1
+        uses: sozo-design/curl@v1.0.2
         with:
-          url: ${{ vars.WATCHTOWER_WEBHOOK_URL }}
-          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ vars.WATCHTOWER_API_KEY }}"}'
+          args: '-X POST ${{ vars.WATCHTOWER_WEBHOOK_URL}} -H "Authorization: Bearer ${{ vars.WATCHTOWER_API_KEY }}" -H "CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}" -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"'
 
   cloudflare:
     name: Deploy to Cloudflare

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Deploy image
         run: |
-          curl -X GET "${{ vars.WATCHTOWER_WEBHOOK_URL}}" \
+          curl -X POST "${{ vars.WATCHTOWER_WEBHOOK_URL}}" \
+          -f --show-error \
           -H "Authorization: Bearer ${{ vars.WATCHTOWER_API_KEY }}" \
           -H "CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}" \
           -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -32,9 +32,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy image
-        uses: sozo-design/curl@v1.0.2
-        with:
-          args: -X GET "${{ vars.WATCHTOWER_WEBHOOK_URL}}" -H "Authorization: Bearer ${{ vars.WATCHTOWER_API_KEY }}" -H "CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}" -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"
+        run: |
+          curl -X GET "${{ vars.WATCHTOWER_WEBHOOK_URL}}" \
+          -H "Authorization: Bearer ${{ vars.WATCHTOWER_API_KEY }}" \
+          -H "CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}" \
+          -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"
 
   cloudflare:
     name: Deploy to Cloudflare

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -40,6 +40,7 @@ jobs:
   cloudflare:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest
+    needs: docker
     environment:
       name: dev
       url: ${{ vars.APP_BASE_URL }}

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -33,10 +33,12 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy image
-        uses: joelwmale/webhook-action@2.4.1
-        with:
-          url: ${{ vars.WATCHTOWER_WEBHOOK_URL }}
-          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_API_KEY }}"}'
+        run: |
+          curl -X POST "${{ vars.WATCHTOWER_WEBHOOK_URL}}" \
+          -f --show-error \
+          -H "Authorization: Bearer ${{ vars.WATCHTOWER_API_KEY }}" \
+          -H "CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}" \
+          -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"
 
   cloudflare:
     name: Deploy to Cloudflare

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: joelwmale/webhook-action@master
         with:
           url: ${{ vars.WATCHTOWER_WEBHOOK_URL }}
-          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_TOKEN }}"}'
+          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_API_KEY }}"}'
 
   cloudflare:
     name: Deploy to Cloudflare

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -41,6 +41,7 @@ jobs:
   cloudflare:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest
+    needs: docker
     environment:
       name: prod
       url: ${{ vars.APP_BASE_URL }}

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -32,6 +32,12 @@ jobs:
           turbo_team: ${{ vars.TURBO_TEAM }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Deploy image
+        uses: joelwmale/webhook-action@master
+        with:
+          url: ${{ vars.WATCHTOWER_WEBHOOK_URL }}
+          headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_TOKEN }}"}'
+
   cloudflare:
     name: Deploy to Cloudflare
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -36,7 +36,7 @@ jobs:
         run: |
           curl -X POST "${{ vars.WATCHTOWER_WEBHOOK_URL}}" \
           -f --show-error \
-          -H "Authorization: Bearer ${{ vars.WATCHTOWER_API_KEY }}" \
+          -H "Authorization: Bearer ${{ secrets.WATCHTOWER_API_KEY }}" \
           -H "CF-Access-Client-Id: ${{ vars.CF_ACCESS_CLIENT_ID }}" \
           -H "CF-Access-Client-Secret: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}"
 

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -33,7 +33,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy image
-        uses: joelwmale/webhook-action@master
+        uses: joelwmale/webhook-action@2.4.1
         with:
           url: ${{ vars.WATCHTOWER_WEBHOOK_URL }}
           headers: '{"CF-Access-Client-Id": "${{ vars.CF_ACCESS_CLIENT_ID }}", "CF-Access-Client-Secret": "${{ secrets.CF_ACCESS_CLIENT_SECRET }}", "Authorization": "Bearer ${{ secrets.WATCHTOWER_API_KEY }}"}'

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -169,4 +169,14 @@ All jobs leverage a TurboRepo remote cache and prune to only run when dependent 
 
 Deployments to the `dev` environment are triggered manually by running the [`Deploy - dev`](.github/workflows/deploy-dev.yaml) workflow in GitHub. Deployments to the `prod` environment are triggered by the [`Deploy - prod`](.github/workflows/deploy-prod.yaml) workflow.
 
-The only part that requires manual deployment is updating the Docker instance running the API server Docker image.
+After the Docker image builds a Watchtower webhook is called to deploy the image into either dev or prod. For this to work the following environment variables must be set in GitHub:
+
+| Variable                 | Description                       |
+| ------------------------ | --------------------------------- |
+| `WATCHTOWER_WEBHOOK_URL` | URL to the Watchtower webhook.    |
+| `CF_ACCESS_CLIENT_ID`    | Client ID for the Cloudflare API. |
+
+And the following secrets must be set in GitHub:
+
+| `WATCHTOWER_API_KEY` | API key for the Watchtower webhook. |
+| `CF_ACCESS_CLIENT_SECRET` | Client secret for the Cloudflare API. |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -169,14 +169,14 @@ All jobs leverage a TurboRepo remote cache and prune to only run when dependent 
 
 Deployments to the `dev` environment are triggered manually by running the [`Deploy - dev`](.github/workflows/deploy-dev.yaml) workflow in GitHub. Deployments to the `prod` environment are triggered by the [`Deploy - prod`](.github/workflows/deploy-prod.yaml) workflow.
 
-After the Docker image builds a Watchtower webhook is called to deploy the image into either dev or prod. For this to work the following environment variables must be set in GitHub:
+After the Docker image builds, a Watchtower webhook is called to deploy the image into either dev or prod. For this to work the following environment variables must be set in GitHub:
 
-| Variable                 | Description                       |
-| ------------------------ | --------------------------------- |
-| `WATCHTOWER_WEBHOOK_URL` | URL to the Watchtower webhook.    |
-| `CF_ACCESS_CLIENT_ID`    | Client ID for the Cloudflare API. |
+| Variable                 | Description                                                                                                            |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| `WATCHTOWER_WEBHOOK_URL` | URL to the Watchtower webhook.                                                                                         |
+| `CF_ACCESS_CLIENT_ID`    | Cloudflare Access client ID used in the webhook headers to authenticate through Cloudflare to the Watchtower instance. |
 
 And the following secrets must be set in GitHub:
 
 | `WATCHTOWER_API_KEY` | API key for the Watchtower webhook. |
-| `CF_ACCESS_CLIENT_SECRET` | Client secret for the Cloudflare API. |
+| `CF_ACCESS_CLIENT_SECRET` | Cloudflare Access client secret used in the webhook headers to authenticate through Cloudflare to the Watchtower instance. |


### PR DESCRIPTION
Fixes #403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Automated deployment now triggers a webhook to deploy Docker images to development and production environments after build and push steps.
	- Deployment jobs are now sequenced to ensure Cloudflare deployment only runs after Docker image deployment.
- **Documentation**
	- Updated deployment instructions to reflect the new automated webhook-based deployment process and required environment variables and secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->