### PR TITLE
Remove RBAC from get stats

### DIFF
--- a/apps/api/src/routes/statistics/get.ts
+++ b/apps/api/src/routes/statistics/get.ts
@@ -1,11 +1,11 @@
-import { verifyUser } from "@/middleware/permissions.js";
+import { verifyApiKey } from "@/middleware/apikey.js";
 import { ScenarioModel } from "@models/scenario.js";
 import { PlanStatisticsResponse, Statistic } from "@workspace/validators";
 import express, { Request, Response } from "express";
 
 const router = express.Router();
 
-router.get("/", verifyUser, async (request: Request, response: Response) => {
+router.get("/", verifyApiKey, async (request: Request, response: Response) => {
   const departures = await ScenarioModel.aggregate<Statistic>([
     { $match: { "plan.dep": { $exists: true, $nin: [undefined, ""] } } },
     { $group: { _id: "$plan.dep", count: { $sum: 1 } } },

--- a/apps/web/src/api/scenarios/scenario-utilities.tsx
+++ b/apps/web/src/api/scenarios/scenario-utilities.tsx
@@ -101,4 +101,5 @@ export function revalidateAfterSave(id?: string) {
   }
   revalidatePath("/lab");
   revalidatePath("/admin/scenarios");
+  revalidatePath("/admin/statistics");
 }

--- a/apps/web/src/api/statistics/fetch-plan-statistics.tsx
+++ b/apps/web/src/api/statistics/fetch-plan-statistics.tsx
@@ -8,11 +8,7 @@ import {
 
 export const fetchPlanStatistics = async () => {
   try {
-    // This isn't cached so a static version of the page doesn't get generated at build time.
-    const response = await getJson("/statistics/plans", {
-      withAuthToken: true,
-      cache: "no-store",
-    });
+    const response = await getJson("/statistics/plans");
 
     if (!response.ok) {
       console.error("Failed to fetch statistics:", response.statusText);


### PR DESCRIPTION
Fixes #418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - After saving a scenario, the cache for the `/admin/statistics` page is now automatically refreshed to reflect the latest data.

- **Chores**
  - Updated authentication for the statistics API endpoint to use API key verification instead of user-based verification.
  - Adjusted how plan statistics are fetched by removing authentication and cache control options from the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->