### PR TITLE
Fix missing space in docs

### DIFF
--- a/apps/web/src/app/lab/documentation.tsx
+++ b/apps/web/src/app/lab/documentation.tsx
@@ -91,7 +91,7 @@ export function Documentation() {
         the functionality in CRC. Airport conditions are shown below the FPE, to
         provide the additional information required to validate the plan and
         issue the clearance. Quick links to view the filed route on SkyVector
-        and FlightAware are accessible via the tooltip on the <code>RTE</code>
+        and FlightAware are accessible via the tooltip on the <code>RTE</code>{" "}
         label.
       </p>
       <p>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved spacing after inline code elements in documentation for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->