### PR TITLE
Get rid of hardcoded URL in metadata

### DIFF
--- a/apps/web/src/app/admin/layout.tsx
+++ b/apps/web/src/app/admin/layout.tsx
@@ -1,9 +1,11 @@
+import { ENV } from "@/lib/environment";
 import type { Metadata } from "next";
 import AdminLayoutClient from "./admin-layout-client"; // Import the new client component
 
 const description = "Administration tools for Clearance Lab";
 const title = "Admin | Clearance Lab";
-const url = "https://clearancelab.badcasserole.com/admin";
+const basePath = "/admin";
+const url = new URL(basePath, ENV.APP_BASE_URL);
 
 export const metadata: Metadata = {
   title,
@@ -20,7 +22,7 @@ export const metadata: Metadata = {
     card: "summary",
     images: [
       {
-        url: `https://clearancelab.badcasserole.com/logo.svg`,
+        url: new URL("/logo.svg", ENV.APP_BASE_URL),
         alt: "Clearance Lab logo, a beaker half filled with blue liquid.",
       },
     ],

--- a/apps/web/src/app/admin/scenarios/layout.tsx
+++ b/apps/web/src/app/admin/scenarios/layout.tsx
@@ -1,8 +1,10 @@
+import { ENV } from "@/lib/environment";
 import type { Metadata } from "next";
 
 const description = "Manage scenarios for Clearance Lab";
 const title = "Scenario editor | Clearance Lab";
-const url = "https://clearancelab.badcasserole.com/admin/scenarios";
+const basePath = "/admin/scenarios";
+const url = new URL(basePath, ENV.APP_BASE_URL);
 
 export const metadata: Metadata = {
   title,
@@ -19,7 +21,7 @@ export const metadata: Metadata = {
     card: "summary",
     images: [
       {
-        url: `https://clearancelab.badcasserole.com/logo.svg`,
+        url: new URL("/logo.svg", ENV.APP_BASE_URL),
         alt: "Clearance Lab logo, a beaker half filled with blue liquid.",
       },
     ],

--- a/apps/web/src/app/admin/scenarios/layout.tsx
+++ b/apps/web/src/app/admin/scenarios/layout.tsx
@@ -33,5 +33,5 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  return <main>{children}</main>;
+  return <main aria-label="Scenario editor content">{children}</main>;
 }

--- a/apps/web/src/app/admin/statistics/layout.tsx
+++ b/apps/web/src/app/admin/statistics/layout.tsx
@@ -1,8 +1,10 @@
+import { ENV } from "@/lib/environment";
 import type { Metadata } from "next";
 
 const description = "View statistics for Clearance Lab";
 const title = "Statistics | Clearance Lab";
-const url = "https://clearancelab.badcasserole.com/admin/statistics";
+const basePath = "/admin/statistics";
+const url = new URL(basePath, ENV.APP_BASE_URL);
 
 export const metadata: Metadata = {
   title,
@@ -19,7 +21,7 @@ export const metadata: Metadata = {
     card: "summary",
     images: [
       {
-        url: `https://clearancelab.badcasserole.com/logo.svg`,
+        url: new URL("/logo.svg", ENV.APP_BASE_URL),
         alt: "Clearance Lab logo, a beaker half filled with blue liquid.",
       },
     ],

--- a/apps/web/src/app/lab/[id]/layout.tsx
+++ b/apps/web/src/app/lab/[id]/layout.tsx
@@ -3,6 +3,7 @@
 // The fetching of data to pass to the page is based off this:
 // https://medium.com/@kishorjena/solving-server-to-client-data-flow-in-next-js-handling-index-and-non-index-pages-62d9194537cc
 import { fetchScenariosByIds } from "@/api/scenarios/fetch-scenarios-by-ids";
+import { ENV } from "@/lib/environment";
 import { Metadata } from "next";
 
 type Parameters = Promise<{ id: string }>;
@@ -22,7 +23,8 @@ export async function generateMetadata({
 
   const title = `${scenario.plan.aid} | Clearance Lab`;
   const description = `Practice flight plan for ${scenario.plan.aid}.`;
-  const url = `https://clearancelab.badcasserole.com/lab/${id}`;
+  const basePath = `/lab/${id}`;
+  const url = new URL(basePath, ENV.APP_BASE_URL);
 
   return {
     title,
@@ -39,7 +41,7 @@ export async function generateMetadata({
       card: "summary",
       images: [
         {
-          url: `https://clearancelab.badcasserole.com/logo.svg`,
+          url: new URL("/logo.svg", ENV.APP_BASE_URL),
           alt: "Clearance Lab logo, a beaker half filled with blue liquid.",
         },
       ],

--- a/apps/web/src/app/lab/layout.tsx
+++ b/apps/web/src/app/lab/layout.tsx
@@ -2,12 +2,14 @@ import { fetchScenariosSummary } from "@/api/scenarios/fetch-scenarios";
 import { LabSidebar } from "@/components/lab-sidebar/lab-sidebar";
 import { Loading } from "@/components/loading";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { ENV } from "@/lib/environment";
 import type { Metadata } from "next";
 import { Suspense } from "react";
 
 const description = "Scenarios to practice your flight plan review skills.";
 const title = "Scenarios | Clearance Lab";
-const url = "https://clearancelab.badcasserole.com/lab";
+const pagePath = "/lab";
+const url = new URL(pagePath, ENV.APP_BASE_URL);
 
 export const metadata: Metadata = {
   title,
@@ -24,7 +26,7 @@ export const metadata: Metadata = {
     card: "summary",
     images: [
       {
-        url: `https://clearancelab.badcasserole.com/logo.svg`,
+        url: new URL("/logo.svg", ENV.APP_BASE_URL),
         alt: "Clearance Lab logo, a beaker half filled with blue liquid.",
       },
     ],

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -18,7 +18,7 @@ export const metadata: Metadata = {
   openGraph: {
     title,
     description,
-    url: ENV.APP_BASE_URL,
+    url: new URL("/", ENV.APP_BASE_URL),
     type: "website",
   },
   twitter: {

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,11 +1,12 @@
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { ENV } from "@/lib/environment";
 import type { Metadata } from "next";
 import "./globals.css";
 
-const description = "Where aspiring controllers sharpen their flight plan review skills.";
+const description =
+  "Where aspiring controllers sharpen their flight plan review skills.";
 const title = "Clearance Lab";
-const url = "https://clearancelab.badcasserole.com";
 
 export const metadata: Metadata = {
   icons: {
@@ -17,7 +18,7 @@ export const metadata: Metadata = {
   openGraph: {
     title,
     description,
-    url,
+    url: ENV.APP_BASE_URL,
     type: "website",
   },
   twitter: {
@@ -26,7 +27,7 @@ export const metadata: Metadata = {
     card: "summary",
     images: [
       {
-        url: `https://clearancelab.badcasserole.com/logo.svg`,
+        url: new URL("/logo.svg", ENV.APP_BASE_URL),
         alt: "Clearance Lab logo, a beaker half filled with blue liquid.",
       },
     ],

--- a/apps/web/src/lib/environment.ts
+++ b/apps/web/src/lib/environment.ts
@@ -26,7 +26,7 @@ const environmentSchema = z
     AUTH0_CLIENT_ID: z.string().optional(),
     AUTH0_DOMAIN: auth0url.optional(), // Optional, but should be a valid URL
     AUTH0_SECRET: z.string().optional(),
-    APP_BASE_URL: auth0url.optional(), // Optional, but should be a valid URL
+    APP_BASE_URL: z.string().url().optional(), // Optional, but should be a valid URL
     DISABLE_AUTH: z
       .preprocess((value) => value === "true" || value === "1", z.boolean())
       .default(false),


### PR DESCRIPTION
Fixes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated all page and image URLs in metadata to be dynamically generated using the environment base URL, ensuring consistency across different deployment environments and removing hardcoded domain names.

- **Style**
  - Reformatted metadata description text for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->