### PR TITLE
Import speeds from vatsim

### DIFF
--- a/.devcontainer/seed/clearancelab.vatsimflightplans.json
+++ b/.devcontainer/seed/clearancelab.vatsimflightplans.json
@@ -12,6 +12,7 @@
       "$date": "2025-04-30T00:25:46.616Z"
     },
     "cruiseAltitude": 350,
+    "cruiseTas": 458,
     "departure": "KPDX",
     "departureTime": {
       "$date": "2025-04-30T03:15:00.000Z"
@@ -47,6 +48,7 @@
       "$date": "2025-04-30T01:31:26.186Z"
     },
     "cruiseAltitude": 370,
+    "cruiseTas": 458,
     "departure": "KPDX",
     "departureTime": {
       "$date": "2025-04-30T02:00:00.000Z"
@@ -82,6 +84,7 @@
       "$date": "2025-04-30T01:58:56.499Z"
     },
     "cruiseAltitude": 320,
+    "cruiseTas": 458,
     "departure": "KPDX",
     "departureTime": {
       "$date": "2025-04-30T02:25:00.000Z"
@@ -117,6 +120,7 @@
       "$date": "2025-04-30T02:24:41.957Z"
     },
     "cruiseAltitude": 370,
+    "cruiseTas": 458,
     "departure": "KPDX",
     "departureTime": {
       "$date": "2025-04-30T02:55:00.000Z"
@@ -151,6 +155,7 @@
       "$date": "2025-04-30T02:53:31.363Z"
     },
     "cruiseAltitude": 370,
+    "cruiseTas": 458,
     "departure": "KPDX",
     "departureTime": {
       "$date": "2025-04-30T03:25:00.000Z"

--- a/apps/api/src/models/vatsim-flight-plan.ts
+++ b/apps/api/src/models/vatsim-flight-plan.ts
@@ -30,6 +30,7 @@ export interface IVatsimFlightPlan {
   departureTime?: Date;
   EDCT?: Date;
   cruiseAltitude?: number;
+  cruiseTas?: number;
   route?: string;
   squawk?: string;
   remarks?: string;
@@ -93,6 +94,7 @@ const VatsimFlightPlanSchema = new Schema<
     departureTime: { type: Date },
     EDCT: { type: Date },
     cruiseAltitude: { type: Number },
+    cruiseTas: { type: Number },
     route: { type: String },
     squawk: { type: String },
     remarks: { type: String },

--- a/apps/api/src/routes/vatsim/flightplan/get.ts
+++ b/apps/api/src/routes/vatsim/flightplan/get.ts
@@ -64,7 +64,7 @@ router.get(
           pilotName: getRandomName(),
           rmk: flightPlan.remarks,
           rte: flightPlan.route,
-          spd: flightPlan.groundspeed,
+          spd: flightPlan.cruiseTas,
           typ: flightPlan.equipmentType,
           eq: flightPlan.equipmentSuffix,
           homeAirport: flightPlan.homeAirport,


### PR DESCRIPTION
Fixes #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added display and storage of cruise true airspeed (TAS) for all flight plans.
- **Bug Fixes**
  - Updated flight plan speed information to show cruise TAS instead of groundspeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->