### PR TITLE
Increase default rate limits, shorten window

### DIFF
--- a/apps/api/src/lib/environment.ts
+++ b/apps/api/src/lib/environment.ts
@@ -8,8 +8,8 @@ config({
 
 const environmentSchema = z
   .object({
-    API_RATE_LIMIT_MAX: z.coerce.number().default(100),
-    API_RATE_LIMIT_MINUTE_WINDOW: z.coerce.number().default(5),
+    API_RATE_LIMIT_MAX: z.coerce.number().default(120),
+    API_RATE_LIMIT_MINUTE_WINDOW: z.coerce.number().default(1),
     AUTH0_AUDIENCE: auth0url.optional(), // Optional, but should be a valid URL
     AUTH0_DOMAIN: auth0url.optional(), // Optional, but should be a valid URL
     DISABLE_AUTH: z


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the default API rate limit to 120 requests per minute and adjusted the time window to 1 minute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->