### PR TITLE
Make RTE tooltip work with touch

### DIFF
--- a/apps/web/src/components/fpe/fpe.tsx
+++ b/apps/web/src/components/fpe/fpe.tsx
@@ -1,15 +1,14 @@
 import { Button } from "@/components/ui/button";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { getFlightAwareUrl, getSkyVectorUrl } from "@workspace/plantools";
 import { Scenario } from "@workspace/validators";
 import * as changeCase from "change-case";
 import { useCallback, useState } from "react";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "../ui/tooltip";
 import { FPEBox } from "./fpe-box";
 import { FPEInput } from "./fpe-input";
 import { FPELabel } from "./fpe-label";
@@ -89,46 +88,49 @@ const FPE = ({ scenario }: FPEProperties) => {
         </FPELabel>
         <FPELabel id="fpe-rte-label" className="fpe-rte-label text-right py-1">
           {skyVectorUrl && flightAwareUrl ? (
-            <TooltipProvider aria-label="Additional information">
-              <Tooltip>
-                <TooltipTrigger className="underline decoration-[var(--color-fpe-foreground)] decoration-dotted decoration-[2px] underline-offset-[4px] cursor-pointer">
-                  RTE
-                </TooltipTrigger>
-                <TooltipContent
-                  className="bg-popover fill-[var(--color-popover)]"
-                  side="right"
+            <Popover>
+              <PopoverTrigger asChild>
+                <button
+                  aria-label="View route information"
+                  className="underline decoration-[var(--color-fpe-foreground)] decoration-dotted decoration-[2px] underline-offset-[4px] cursor-pointer bg-transparent border-none text-[var(--color-fpe-foreground)] p-0 h-auto font-inherit text-sm"
                 >
-                  {skyVectorUrl && (
-                    <p>
-                      <Button variant="link">
-                        <a
-                          href={skyVectorUrl ?? ""}
-                          target="_blank"
-                          rel="noreferrer"
-                          aria-label="View flight plan on SkyVector, opens in new tab"
-                        >
-                          View on SkyVector
-                        </a>
-                      </Button>
-                    </p>
-                  )}
-                  {flightAwareUrl && (
-                    <p>
-                      <Button variant="link">
-                        <a
-                          href={flightAwareUrl ?? ""}
-                          target="_blank"
-                          rel="noreferrer"
-                          aria-label="View flight plan on FlightAware, opens in new tab"
-                        >
-                          View on FlightAware
-                        </a>
-                      </Button>
-                    </p>
-                  )}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
+                  RTE
+                </button>
+              </PopoverTrigger>
+              <PopoverContent
+                className="bg-popover fill-[var(--color-popover)] w-auto"
+                side="right"
+              >
+                {skyVectorUrl && (
+                  <p>
+                    <Button variant="link" asChild className="p-0 h-auto">
+                      <a
+                        href={skyVectorUrl ?? ""}
+                        target="_blank"
+                        rel="noreferrer"
+                        aria-label="View flight plan on SkyVector, opens in new tab"
+                      >
+                        View on SkyVector
+                      </a>
+                    </Button>
+                  </p>
+                )}
+                {flightAwareUrl && (
+                  <p>
+                    <Button variant="link" asChild className="p-0 h-auto mt-1">
+                      <a
+                        href={flightAwareUrl ?? ""}
+                        target="_blank"
+                        rel="noreferrer"
+                        aria-label="View flight plan on FlightAware, opens in new tab"
+                      >
+                        View on FlightAware
+                      </a>
+                    </Button>
+                  </p>
+                )}
+              </PopoverContent>
+            </Popover>
           ) : (
             "RTE"
           )}


### PR DESCRIPTION
Fixes #436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the route information ("RTE") display to use a popover instead of a tooltip, providing a more interactive way to access SkyVector and FlightAware links.
- **Style**
  - Improved styling for the "RTE" label and popover content for better accessibility and visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->