### PR TITLE
Add controller name to CRAFT edit section

### DIFF
--- a/apps/web/src/app/admin/scenarios/edit/[id]/page.tsx
+++ b/apps/web/src/app/admin/scenarios/edit/[id]/page.tsx
@@ -18,10 +18,13 @@ export default async function Page({ params }: { params: Parameters }) {
 
   const scenario = scenarios[0];
 
-  // Older scenarios may not have a home airport. If there isn't one defined set it to the empty
+  // Older scenarios may some fields missing. If they're undefined set them to the empty
   // string to ensure there aren't errors from React about going from uncontrolled to controlled
   // when a value is set.
   scenario.plan.homeAirport ??= "";
+  if (scenario.craft) {
+    scenario.craft.controllerName ??= "";
+  }
 
   return (
     <div>

--- a/apps/web/src/components/scenario-form/craft-section.tsx
+++ b/apps/web/src/components/scenario-form/craft-section.tsx
@@ -57,6 +57,24 @@ export function CraftSection() {
             <div>
               <FormField
                 control={control}
+                name="craft.controllerName"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Controller name</FormLabel>
+                    <FormDescription>
+                      The way to say the controller&apos;s name.
+                    </FormDescription>
+                    <FormControl>
+                      <Input id="controllerName" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div>
+              <FormField
+                control={control}
                 name="craft.telephony"
                 render={({ field }) => (
                   <FormItem>


### PR DESCRIPTION
Fixes #450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "Controller name" field to the CRAFT clearance details section in scenario forms.

- **Bug Fixes**
	- Improved handling of missing fields in older scenarios to prevent input warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->