### PR TITLE
Spell out numbers for departure frequency and beacon

### DIFF
--- a/apps/web/src/components/craft.tsx
+++ b/apps/web/src/components/craft.tsx
@@ -30,9 +30,7 @@ export function Craft({ scenario }: CraftProperties) {
         {craft?.altitude && <span>{capitalizeFirst(craft.altitude)}.</span>}
         <span>Departure {getFormattedDepartureFrequency(scenario)}.</span>
         {scenario.plan.bcn && (
-          <span>
-            Squawk {spellSquawk(scenario.plan.bcn.toString().padStart(4, "0"))}.
-          </span>
+          <span>Squawk {spellSquawk(scenario.plan.bcn.toString())}.</span>
         )}
       </p>
     </section>

--- a/apps/web/src/components/craft.tsx
+++ b/apps/web/src/components/craft.tsx
@@ -3,6 +3,7 @@ import {
   getFormattedClearanceLimit,
   getFormattedDepartureFrequency,
   getTelephony,
+  spellSquawk,
 } from "@workspace/plantools";
 import { Scenario } from "@workspace/validators";
 
@@ -29,7 +30,9 @@ export function Craft({ scenario }: CraftProperties) {
         {craft?.altitude && <span>{capitalizeFirst(craft.altitude)}.</span>}
         <span>Departure {getFormattedDepartureFrequency(scenario)}.</span>
         {scenario.plan.bcn && (
-          <span>Squawk {scenario.plan.bcn.toString().padStart(4, "0")}.</span>
+          <span>
+            Squawk {spellSquawk(scenario.plan.bcn.toString().padStart(4, "0"))}.
+          </span>
         )}
       </p>
     </section>

--- a/packages/plantools/src/faa-speech.ts
+++ b/packages/plantools/src/faa-speech.ts
@@ -1,0 +1,24 @@
+const smallNumbers: Record<string, string> = {
+  "0": "zero",
+  "1": "one",
+  "2": "two",
+  "3": "three",
+  "4": "four",
+  "5": "five",
+  "6": "six",
+  "7": "seven",
+  "8": "eight",
+  "9": "nine",
+};
+
+export function spellSquawk(code: string): string {
+  const digits = code.replaceAll(/\D/g, "").padStart(4, "0").slice(-4);
+  return (
+    digits
+      // eslint-disable-next-line unicorn/prefer-spread
+      .split("")
+      // eslint-disable-next-line security/detect-object-injection
+      .map((d) => smallNumbers[d])
+      .join(" ")
+  );
+}

--- a/packages/plantools/src/faa-speech.ts
+++ b/packages/plantools/src/faa-speech.ts
@@ -1,4 +1,6 @@
-const smallNumbers: Record<string, string> = {
+/* eslint-disable unicorn/prefer-spread */
+/* eslint-disable security/detect-object-injection */
+const digitWords: Record<string, string> = {
   "0": "zero",
   "1": "one",
   "2": "two",
@@ -13,12 +15,26 @@ const smallNumbers: Record<string, string> = {
 
 export function spellSquawk(code: string): string {
   const digits = code.replaceAll(/\D/g, "").padStart(4, "0").slice(-4);
-  return (
-    digits
-      // eslint-disable-next-line unicorn/prefer-spread
-      .split("")
-      // eslint-disable-next-line security/detect-object-injection
-      .map((d) => smallNumbers[d])
-      .join(" ")
-  );
+  return digits
+    .split("")
+    .map((d) => digitWords[d])
+    .join(" ");
+}
+
+export function spellFrequency(freq: string | number): string {
+  const stringVersion = typeof freq === "number" ? freq.toFixed(3) : freq;
+  const [left, right] = stringVersion.split(".");
+
+  const leftPart = left
+    .replaceAll(/\D/g, "")
+    .split("")
+    .map((d) => digitWords[d])
+    .join(" ");
+  const rightTrimmed = right.replace(/0+$/, ""); // remove trailing zeros
+  const rightPart = rightTrimmed
+    .split("")
+    .map((d) => digitWords[d])
+    .join(" ");
+
+  return `${leftPart} point ${rightPart}`;
 }

--- a/packages/plantools/src/faa-speech.ts
+++ b/packages/plantools/src/faa-speech.ts
@@ -1,5 +1,6 @@
-/* eslint-disable unicorn/prefer-spread */
+/* eslint-disable @typescript-eslint/no-misused-spread */
 /* eslint-disable security/detect-object-injection */
+
 const digitWords: Record<string, string> = {
   "0": "zero",
   "1": "one",
@@ -15,25 +16,19 @@ const digitWords: Record<string, string> = {
 
 export function spellSquawk(code: string): string {
   const digits = code.replaceAll(/\D/g, "").padStart(4, "0").slice(-4);
-  return digits
-    .split("")
-    .map((d) => digitWords[d])
-    .join(" ");
+  return [...digits].map((d: string) => digitWords[d]).join(" ");
 }
 
 export function spellFrequency(freq: string | number): string {
   const stringVersion = typeof freq === "number" ? freq.toFixed(3) : freq;
   const [left, right] = stringVersion.split(".");
 
-  const leftPart = left
-    .replaceAll(/\D/g, "")
-    .split("")
-    .map((d) => digitWords[d])
+  const leftPart = [...left.replaceAll(/\D/g, "")]
+    .map((d: string) => digitWords[d])
     .join(" ");
   const rightTrimmed = right.replace(/0+$/, ""); // remove trailing zeros
-  const rightPart = rightTrimmed
-    .split("")
-    .map((d) => digitWords[d])
+  const rightPart = [...rightTrimmed]
+    .map((d: string) => digitWords[d])
     .join(" ");
 
   return `${leftPart} point ${rightPart}`;

--- a/packages/plantools/src/faa-speech.ts
+++ b/packages/plantools/src/faa-speech.ts
@@ -26,10 +26,11 @@ export function spellFrequency(freq: string | number): string {
   const leftPart = [...left.replaceAll(/\D/g, "")]
     .map((d: string) => digitWords[d])
     .join(" ");
-  const rightTrimmed = right.replace(/0+$/, ""); // remove trailing zeros
-  const rightPart = [...rightTrimmed]
-    .map((d: string) => digitWords[d])
-    .join(" ");
 
-  return `${leftPart} point ${rightPart}`;
+  // Handle case when there's no decimal point
+  const rightPart = right
+    ? [...right.replace(/0+$/, "")].map((d: string) => digitWords[d]).join(" ")
+    : "";
+
+  return right ? `${leftPart} point ${rightPart}` : leftPart;
 }

--- a/packages/plantools/src/formatting.ts
+++ b/packages/plantools/src/formatting.ts
@@ -1,4 +1,5 @@
 import { Plan, Scenario } from "@workspace/validators";
+import { spellFrequency } from "./faa-speech";
 
 const AirlineCodeRegexPattern = /\b([A-Za-z]{3})([A-Za-z\d]+)\b/;
 
@@ -134,6 +135,6 @@ export const getFormattedDepartureFrequency = (scenario: Scenario) => {
   const departure = craft?.frequency ?? "offline";
 
   return typeof departure === "number"
-    ? `is ${departure.toFixed(3)}`
+    ? `is ${spellFrequency(departure)}`
     : departure;
 };

--- a/packages/plantools/src/index.ts
+++ b/packages/plantools/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./faa-speech";
 export * from "./form-data-utilities";
 export * from "./formatting";
 export * from "./random";

--- a/packages/plantools/tsconfig.json
+++ b/packages/plantools/tsconfig.json
@@ -5,6 +5,7 @@
     "noEmit": true,
     "outDir": "./dist",
     "sourceMap": true,
+    "target": "es2015",
     "types": ["node"]
   },
   "exclude": ["node_modules", "dist"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Squawk codes and radio frequencies are now displayed in a spelled-out, easy-to-read format in clearance information.
- **Improvements**
  - Enhanced formatting for departure frequencies to improve clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->