### PR TITLE
Remove the tips from the main page

### DIFF
--- a/apps/web/src/app/lab/documentation.tsx
+++ b/apps/web/src/app/lab/documentation.tsx
@@ -88,7 +88,10 @@ export function Documentation() {
         Select scenarios from the sidebar to practice, or use the random
         scenario button to show a random scenario from the list. You can also
         press the{" "}
-        <kbd className="rounded border border-muted px-1.5 py-0.5 text-sm font-mono bg-muted text-muted-foreground">
+        <kbd
+          aria-keyshortcuts="S"
+          className="rounded border border-muted px-1.5 py-0.5 text-sm font-mono bg-muted text-muted-foreground"
+        >
           S
         </kbd>{" "}
         key to show a random scenario.
@@ -116,7 +119,10 @@ export function Documentation() {
       <p>
         The scenario answer is revealed by clicking the <code>Show answer</code>{" "}
         button or by pressing the{" "}
-        <kbd className="rounded border border-muted px-1.5 py-0.5 text-sm font-mono bg-muted text-muted-foreground">
+        <kbd
+          aria-keyshortcuts="A"
+          className="rounded border border-muted px-1.5 py-0.5 text-sm font-mono bg-muted text-muted-foreground"
+        >
           A
         </kbd>{" "}
         key.

--- a/apps/web/src/app/lab/documentation.tsx
+++ b/apps/web/src/app/lab/documentation.tsx
@@ -84,6 +84,15 @@ export function Documentation() {
         includes any corrections that may be required and the correct clearance
         phrasing.
       </p>
+      <p>
+        Select scenarios from the sidebar to practice, or use the random
+        scenario button to show a random scenario from the list. You can also
+        press the{" "}
+        <kbd className="rounded border border-muted px-1.5 py-0.5 text-sm font-mono bg-muted text-muted-foreground">
+          S
+        </kbd>{" "}
+        key to show a random scenario.
+      </p>
 
       <h2>The Flight Plan Editor</h2>
       <p>
@@ -127,18 +136,6 @@ export function Documentation() {
         Try revealing the answer to the scenario for flight plan shown above:
       </p>
       <Answer scenario={scenario} className="mt-4" />
-      <h2>Tips</h2>
-      <p>
-        Press the{" "}
-        <kbd className="rounded border border-muted px-1.5 py-0.5 text-sm font-mono bg-muted text-muted-foreground">
-          S
-        </kbd>{" "}
-        key to show a random scenario. Press the{" "}
-        <kbd className="rounded border border-muted px-1.5 py-0.5 text-sm font-mono bg-muted text-muted-foreground">
-          A
-        </kbd>{" "}
-        key to show the answer.
-      </p>
     </section>
   );
 }


### PR DESCRIPTION
Fixes #454

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions to guide users to select scenarios from the sidebar or use the random scenario button.
  - Clarified that pressing the "S" key shows a random scenario in the introduction.
  - Enhanced accessibility for the "A" key shortcut in the "Answers" section.
  - Removed the redundant "Tips" section for a more streamlined experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->