### PR TITLE
DCT shouldn't show in the example scenario

### DIFF
--- a/apps/web/src/app/lab/documentation.tsx
+++ b/apps/web/src/app/lab/documentation.tsx
@@ -39,7 +39,7 @@ const scenario: Scenario = {
     eq: "X",
     homeAirport: "KPDX",
     pilotName: "Dakota",
-    rte: "LAVAA7 YKM DCT YXC DCT MIREK/N0448F360 Q995 OILRS OILRS2",
+    rte: "LAVAA7 YKM YXC MIREK/N0448F360 Q995 OILRS OILRS2",
     rmk: "RALT/KSFO PHTO SIMBRIEF/FIRST IFR FLIGHT/ VERY NEW TO VATSIM",
     spd: 200,
     typ: "A320",


### PR DESCRIPTION
Fixes #516

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the displayed flight plan route by removing unnecessary "DCT" segments for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->