### PR TITLE
Departure frequencies ending in .000 don't say "point zero" at the end

### DIFF
--- a/packages/plantools/src/faa-speech.ts
+++ b/packages/plantools/src/faa-speech.ts
@@ -77,7 +77,6 @@ export function spellFrequency(freq: string | number): string {
         .join(" ")
     : "";
 
-  console.log(`Right: "${right}"`);
   return right ? `${leftPart} point ${rightPart}` : leftPart;
 }
 

--- a/packages/plantools/src/faa-speech.ts
+++ b/packages/plantools/src/faa-speech.ts
@@ -68,15 +68,16 @@ export function spellFrequency(freq: string | number): string {
     .map((d: string) => digitWords[Number(d)])
     .join(" ");
 
-  // Handle case when there's no decimal point
+  // Handle case when there's no decimal portion
   const rightPart = right
     ? [
-        ...right.replace(/0+$/, ""),
+        ...(right.replace(/0+$/, "") || "0"), // This handles the case of numbers like 126.000, where at least one zero needs to get left for proper telephony.
       ]
         .map((d: string) => digitWords[Number(d)])
         .join(" ")
     : "";
 
+  console.log(`Right: "${right}"`);
   return right ? `${leftPart} point ${rightPart}` : leftPart;
 }
 


### PR DESCRIPTION
Fixes #524

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of decimal portions in frequency spelling to ensure correct pronunciation, especially for values with trailing zeros (e.g., "126.000" now retains a single zero in the decimal part).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->