### PR TITLE
Get rid of "you can issue the clearance"

### DIFF
--- a/apps/web/src/components/explanations/explanations.tsx
+++ b/apps/web/src/components/explanations/explanations.tsx
@@ -1,5 +1,4 @@
 import { Scenario } from "@workspace/validators";
-import { CalloutBox } from "../callout-box";
 import { ExplanationItem } from "./explanation-item";
 
 interface ExplanationsProperties {
@@ -13,16 +12,6 @@ export function Explanations({ scenario }: ExplanationsProperties) {
 
   return (
     <div role="region" aria-label="Clearance status and explanations">
-      {scenario.canClear ? (
-        <CalloutBox variant="ok" className="mb-2">
-          You can issue the clearance!
-        </CalloutBox>
-      ) : (
-        <CalloutBox variant="warning">
-          You cannot issue the clearance yet.
-        </CalloutBox>
-      )}
-
       <div className="mt-2" aria-label="Explanation details">
         {scenario.explanations.map((explanation, index) => (
           <ExplanationItem


### PR DESCRIPTION
Fixes #533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the clearance status message from the explanations section, simplifying the display to show only the list of explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->