### PR TITLE
Show hasAudio instead of canClear

### DIFF
--- a/.devcontainer/seed/clearancelab.scenarios.json
+++ b/.devcontainer/seed/clearancelab.scenarios.json
@@ -22,6 +22,7 @@
         "level": "warning"
       }
     ],
+    "hasAudio": false,
     "isValid": false,
     "plan": {
       "aid": "ASA1160",
@@ -57,6 +58,7 @@
       "telephony": "Alaska seventeen"
     },
     "explanations": [],
+    "hasAudio": false,
     "isValid": true,
     "plan": {
       "aid": "ASA17",
@@ -127,6 +129,7 @@
       "telephony": "November three fife seven juliet kilo heavy"
     },
     "explanations": [],
+    "hasAudio": false,
     "isValid": true,
     "plan": {
       "aid": "N357JK",
@@ -162,6 +165,7 @@
       "telephony": "Alaska four ninety-eight"
     },
     "explanations": [],
+    "hasAudio": false,
     "isValid": true,
     "plan": {
       "aid": "ASA498",
@@ -273,6 +277,7 @@
       "$date": "2025-05-02T19:17:20.548Z"
     },
     "explanations": [],
+    "hasAudio": false,
     "isValid": true,
     "plan": {
       "_id": {

--- a/apps/api/src/models/scenario.ts
+++ b/apps/api/src/models/scenario.ts
@@ -18,7 +18,7 @@ export interface Scenario {
   craft?: Craft;
   depAirportInfo?: AirportInfoData;
   destAirportInfo?: AirportInfoData;
-  hasAudio?: boolean;
+  hasAudio: boolean;
   isValid: boolean;
   plan: Plan;
   explanations: Explanation[];
@@ -29,6 +29,7 @@ export interface ScenarioSummary {
   _id: Types.ObjectId;
   isValid: boolean;
   canClear: boolean;
+  hasAudio: boolean;
   plan: {
     dep?: string;
     dest?: string;
@@ -160,7 +161,7 @@ ScenarioSchema.statics.findSummary = async function (
         : {};
 
     const results = await this.find(query)
-      .select("isValid canClear plan.dep plan.dest plan.aid plan.rte")
+      .select("isValid canClear hasAudio plan.dep plan.dest plan.aid plan.rte")
       .sort({ "plan.dep": 1, "plan.dest": 1, "plan.aid": 1 })
       .lean()
       .exec();

--- a/apps/api/src/routes/statistics/get.ts
+++ b/apps/api/src/routes/statistics/get.ts
@@ -54,6 +54,23 @@ router.get("/", verifyApiKey, async (request: Request, response: Response) => {
     { $sort: { item: 1 } },
   ]);
 
+  const hasAudio = await ScenarioModel.aggregate<Statistic>([
+    {
+      $group: {
+        _id: {
+          $cond: [
+            { $eq: ["$hasAudio", true] },
+            "Yes",
+            "No",
+          ],
+        },
+        count: { $sum: 1 },
+      },
+    },
+    { $project: { _id: 0, item: "$_id", count: "$count" } },
+    { $sort: { item: 1 } },
+  ]);
+
   const responseData: PlanStatisticsResponse = {
     success: true,
     data: {
@@ -61,6 +78,7 @@ router.get("/", verifyApiKey, async (request: Request, response: Response) => {
       destinations,
       canClear,
       isValid,
+      hasAudio,
     },
   };
 

--- a/apps/web/src/app/admin/scenarios/use-admin-columns.tsx
+++ b/apps/web/src/app/admin/scenarios/use-admin-columns.tsx
@@ -65,9 +65,9 @@ export function useAdminColumns() {
             filterLabel: "is valid",
           },
         }),
-        columnHelper.accessor("canClear", {
-          id: "canClear",
-          header: () => <span aria-label="Can clear column">Can clear</span>,
+        columnHelper.accessor("hasAudio", {
+          id: "hasAudio",
+          header: () => <span aria-label="Has audio column">Has audio</span>,
           cell: (info) => (
             <div className="flex justify-center items-center">
               <YesNoIcon value={info.getValue()} />
@@ -77,7 +77,7 @@ export function useAdminColumns() {
             filterVariant: "boolean",
             columnHeaderJustification: "justify-center",
             width: "w-[120px]",
-            filterLabel: "can clear",
+            filterLabel: "Has audio",
           },
         }),
         columnHelper.display({

--- a/apps/web/src/app/admin/statistics/client-section.tsx
+++ b/apps/web/src/app/admin/statistics/client-section.tsx
@@ -36,15 +36,21 @@ export default function ClientSection({ statistics }: ClientSectionProperties) {
           baseUrl="/admin/scenarios?columnFilters.plan.dest="
         />
         <PieChart
+          chartData={statistics.isValid}
+          title="Is Valid"
+          baseUrl="/admin/scenarios?columnFilters.isValid="
+          isBoolean={true}
+        />
+        <PieChart
           chartData={statistics.canClear}
           title="Can clear"
           baseUrl="/admin/scenarios?columnFilters.canClear="
           isBoolean={true}
         />
         <PieChart
-          chartData={statistics.isValid}
-          title="Is Valid"
-          baseUrl="/admin/scenarios?columnFilters.isValid="
+          chartData={statistics.hasAudio}
+          title="Has audio"
+          baseUrl="/admin/scenarios?columnFilters.hasAudio="
           isBoolean={true}
         />
       </div>

--- a/packages/validators/src/plan-statistics.ts
+++ b/packages/validators/src/plan-statistics.ts
@@ -11,6 +11,7 @@ export const planStatisticsSchema = z.object({
   destinations: z.array(statisticSchema),
   canClear: z.array(statisticSchema),
   isValid: z.array(statisticSchema),
+  hasAudio: z.array(statisticSchema),
 });
 
 export const planStatisticsSuccessSchema = z.object({
@@ -31,6 +32,7 @@ export interface PlanStatistics {
   destinations: Statistic[];
   canClear: Statistic[];
   isValid: Statistic[];
+  hasAudio: Statistic[];
 }
 export type PlanStatisticsResponse = z.infer<
   typeof planStatisticsResponseSchema

--- a/packages/validators/src/scenario-summary.ts
+++ b/packages/validators/src/scenario-summary.ts
@@ -6,6 +6,7 @@ export const scenarioSummarySchema = z.object({
   _id: z.string(),
   isValid: z.boolean(),
   canClear: z.boolean(),
+  hasAudio: z.boolean(),
   plan: z.object({
     dep: z.string().optional(),
     dest: z.string().optional(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a "Has audio" field to scenario data and made it visible in scenario tables and statistics.
  - Updated admin statistics to include a new pie chart for scenarios with or without audio.
- **Enhancements**
  - Improved scenario table columns to display audio availability instead of previous criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->