### PR TITLE
Don't let blank clearance limits override the airport name

### DIFF
--- a/packages/plantools/src/formatting.ts
+++ b/packages/plantools/src/formatting.ts
@@ -41,7 +41,12 @@ export const formatAirportName = (name?: string) => {
  */
 export const getFormattedClearanceLimit = (scenario: Scenario) => {
   const { destAirportInfo, craft } = scenario;
-  const clearanceLimit = craft?.clearanceLimit ?? destAirportInfo?.name;
+  const trimmedLimit = craft?.clearanceLimit?.trim();
+
+  const clearanceLimit =
+    trimmedLimit && trimmedLimit.length > 0
+      ? trimmedLimit
+      : destAirportInfo?.name;
 
   return formatAirportName(clearanceLimit);
 };


### PR DESCRIPTION
Fixes #546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of clearance limit values to ensure entries containing only whitespace are correctly replaced with the destination airport name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->