### PR TITLE
Support generating external and internal random beacons

### DIFF
--- a/apps/api/src/routes/vatsim/flightplan/get.ts
+++ b/apps/api/src/routes/vatsim/flightplan/get.ts
@@ -3,8 +3,8 @@ import { AirlineModel } from "@models/airlines.js";
 import { VatsimFlightPlanModel } from "@models/vatsim-flight-plan.js";
 import {
   convertToNumber,
-  getRandomBcn,
   getRandomCid,
+  getRandomExternalBcn,
   getRandomName,
   getRandomVatsimId,
   getWeightClass,
@@ -75,7 +75,7 @@ router.get(
         plan: {
           aid: flightPlan.callsign,
           alt: flightPlan.cruiseAltitude,
-          bcn: convertToNumber(flightPlan.squawk) ?? getRandomBcn(),
+          bcn: convertToNumber(flightPlan.squawk) ?? getRandomExternalBcn(),
           cid: getRandomCid(),
           dep: flightPlan.departure,
           dest: flightPlan.arrival,
@@ -96,6 +96,7 @@ router.get(
         },
         isValid: false,
         canClear: false,
+        hasAudio: false,
         explanations: [],
       };
 

--- a/apps/web/src/components/scenario-form/plan-section.tsx
+++ b/apps/web/src/components/scenario-form/plan-section.tsx
@@ -17,10 +17,16 @@ import { Input } from "@/components/ui/input";
 import { ReactFormSwitch } from "@/components/ui/react-form-switch";
 import { Textarea } from "@/components/ui/textarea";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   getRandomAirportCode,
-  getRandomBcn,
   getRandomCallsign,
   getRandomCid,
+  getRandomExternalBcn,
+  getRandomInternalBcn,
   getRandomName,
   getRandomVatsimId,
 } from "@workspace/plantools";
@@ -216,18 +222,32 @@ export function PlanSection({ isEditMode }: PlanSectionProperties) {
               <FormItem>
                 <FormLabel>
                   BCN
-                  <button
-                    type="button"
-                    aria-label="Generate random beacon"
-                    tabIndex={-1}
-                    aria-hidden="false"
-                    onClick={() => {
-                      const random = getRandomBcn();
-                      field.onChange(random.toString().padStart(4, "0"));
-                    }}
-                  >
-                    <RefreshCwIcon width={14} height={14} />
-                  </button>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label="Generate random beacon"
+                        tabIndex={-1}
+                        aria-hidden="false"
+                        onClick={(event) => {
+                          const random = event.shiftKey
+                            ? getRandomInternalBcn()
+                            : getRandomExternalBcn();
+                          field.onChange(random.toString().padStart(4, "0"));
+                        }}
+                      >
+                        <RefreshCwIcon width={14} height={14} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <>
+                        Generates a random beacon for external flights.
+                        <br />
+                        Shift+click to generate a random beacon for internal
+                        flights.
+                      </>
+                    </TooltipContent>
+                  </Tooltip>
                 </FormLabel>
                 <FormControl>
                   <Input

--- a/packages/plantools/src/random.ts
+++ b/packages/plantools/src/random.ts
@@ -39,6 +39,22 @@ const airportCodes = [
 Object.freeze(airportCodes);
 // cSpell:enable
 
+// prettier-ignore
+const externalBeaconRanges: [number, number][] = [
+    [3501, 3577], 
+    [6601, 6677], 
+    [1501, 1577],
+    [1601, 1677],
+  ];
+
+// prettier-ignore
+const internalBeaconRanges: [number, number][] = [
+    [4601, 4677], 
+    [4701, 4777], 
+    [5101, 5177],
+    [5201, 5277],
+  ];
+
 /**
  * Generates a random integer between the specified min and max values, inclusive.
  * @param min The minimum value.
@@ -93,7 +109,7 @@ export function getRandomScenario(): Scenario {
     plan: {
       aid: getRandomCallsign(),
       alt: 0,
-      bcn: getRandomBcn(),
+      bcn: getRandomExternalBcn(),
       cid: getRandomCid(),
       dep: "",
       dest: "",
@@ -134,20 +150,28 @@ export function getRandomName(): string {
 }
 
 /**
- * Generates a random beacon from the range of valid beacons in ZSE.
+ * Generates a random beacon from the range of valid beacons in ZSE for flights departing ZSE airspace.
  * @returns A random beacon
  */
-export function getRandomBcn(): number {
-  // These are the ZSE ranges.
-  // prettier-ignore
-  const ranges: [number, number][] = [
-    [ 650,  677], 
-    [2236, 2277], 
-    [3430, 3477],
-    [7412, 7477],
-  ];
+export function getRandomExternalBcn(): number {
+  const selectedRange =
+    externalBeaconRanges[
+      Math.floor(Math.random() * externalBeaconRanges.length)
+    ];
+  const value = getRandomInt(selectedRange[0], selectedRange[1]);
 
-  const selectedRange = ranges[Math.floor(Math.random() * ranges.length)];
+  return value;
+}
+
+/**
+ * Generates a random beacon from the range of valid beacons in ZSE for flights departing ZSE airspace.
+ * @returns A random beacon
+ */
+export function getRandomInternalBcn(): number {
+  const selectedRange =
+    internalBeaconRanges[
+      Math.floor(Math.random() * internalBeaconRanges.length)
+    ];
   const value = getRandomInt(selectedRange[0], selectedRange[1]);
 
   return value;


### PR DESCRIPTION
Fixes #538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to generate either external or internal beacon codes when creating a flight plan, with a tooltip explaining shift-click functionality.
  - Scenario details now include an indicator for audio availability.

- **Enhancements**
  - Improved random beacon code generation by distinguishing between external and internal ranges for more accurate assignments.

- **User Interface**
  - Added contextual tooltips to the beacon code generation button for better user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->