### PR TITLE
Add a way to omit portions of CRAFT

### DIFF
--- a/apps/web/src/components/craft-table.tsx
+++ b/apps/web/src/components/craft-table.tsx
@@ -22,6 +22,12 @@ export function CraftTable({ scenario, className }: CraftTableProperties) {
     return null;
   }
 
+  // Check for special values that indicate these portions of CRAFT should have empty values
+  // displayed.
+  const hasClearanceLimit = craft.clearanceLimit !== "none";
+  const hasRoute = craft.route !== "none";
+  const hasAltitude = craft.altitude !== "none";
+
   return (
     <div className={cn("flex flex-col items-center", className)}>
       <p className="font-bold">CRAFT</p>
@@ -37,21 +43,27 @@ export function CraftTable({ scenario, className }: CraftTableProperties) {
             </TableRow>
             <TableRow key="C">
               <TableCell>C</TableCell>
-              <TableCell className="whitespace-normal">
-                Cleared to {getFormattedClearanceLimit(scenario)}
-              </TableCell>
+              {hasClearanceLimit && (
+                <TableCell className="whitespace-normal">
+                  Cleared to {getFormattedClearanceLimit(scenario)}
+                </TableCell>
+              )}
             </TableRow>
             <TableRow key="R">
               <TableCell>R</TableCell>
-              <TableCell className="whitespace-normal">
-                via the {craft.route}.
-              </TableCell>
+              {hasRoute && (
+                <TableCell className="whitespace-normal">
+                  via the {craft.route}.
+                </TableCell>
+              )}
             </TableRow>
             <TableRow key="A">
               <TableCell>A</TableCell>
-              <TableCell className="whitespace-normal">
-                {capitalizeFirst(craft.altitude ?? "")}.
-              </TableCell>
+              {hasAltitude && (
+                <TableCell className="whitespace-normal">
+                  {capitalizeFirst(craft.altitude ?? "")}.
+                </TableCell>
+              )}
             </TableRow>
             <TableRow key="F">
               <TableCell>F</TableCell>

--- a/apps/web/src/components/craft-table.tsx
+++ b/apps/web/src/components/craft-table.tsx
@@ -43,27 +43,22 @@ export function CraftTable({ scenario, className }: CraftTableProperties) {
             </TableRow>
             <TableRow key="C">
               <TableCell>C</TableCell>
-              {hasClearanceLimit && (
-                <TableCell className="whitespace-normal">
-                  Cleared to {getFormattedClearanceLimit(scenario)}
-                </TableCell>
-              )}
+              <TableCell className="whitespace-normal">
+                {hasClearanceLimit &&
+                  `Cleared to ${getFormattedClearanceLimit(scenario)}`}
+              </TableCell>
             </TableRow>
             <TableRow key="R">
               <TableCell>R</TableCell>
-              {hasRoute && (
-                <TableCell className="whitespace-normal">
-                  via the {craft.route}.
-                </TableCell>
-              )}
+              <TableCell className="whitespace-normal">
+                {hasRoute && `via the ${craft.route}.`}
+              </TableCell>
             </TableRow>
             <TableRow key="A">
               <TableCell>A</TableCell>
-              {hasAltitude && (
-                <TableCell className="whitespace-normal">
-                  {capitalizeFirst(craft.altitude ?? "")}.
-                </TableCell>
-              )}
+              <TableCell className="whitespace-normal">
+                {hasAltitude && `${capitalizeFirst(craft.altitude ?? "")}.`}
+              </TableCell>
             </TableRow>
             <TableRow key="F">
               <TableCell>F</TableCell>


### PR DESCRIPTION
Fixes #558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The CRAFT table now hides the "C", "R", and "A" rows when their values are set to "none", resulting in a cleaner and more relevant display for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->