### PR TITLE
Hide more/all craft if necessary

### DIFF
--- a/apps/web/src/components/craft-table.tsx
+++ b/apps/web/src/components/craft-table.tsx
@@ -5,7 +5,6 @@ import {
   getFormattedClearanceLimit,
   getFormattedDepartureFrequency,
   getTelephony,
-  spellSquawk,
 } from "@workspace/plantools";
 import { Scenario } from "@workspace/validators";
 
@@ -27,6 +26,20 @@ export function CraftTable({ scenario, className }: CraftTableProperties) {
   const hasClearanceLimit = craft.clearanceLimit !== "none";
   const hasRoute = craft.route !== "none";
   const hasAltitude = craft.altitude !== "none";
+  const hasSquawk = scenario.plan.bcn;
+  const hasDeparture =
+    scenario.airportConditions.departureOnline && craft.frequency !== 0;
+
+  if (
+    !hasAltitude &&
+    !hasClearanceLimit &&
+    !hasDeparture &&
+    !hasRoute &&
+    !hasSquawk
+  ) {
+    // eslint-disable-next-line unicorn/no-null
+    return null;
+  }
 
   return (
     <div className={cn("flex flex-col items-center", className)}>
@@ -63,13 +76,15 @@ export function CraftTable({ scenario, className }: CraftTableProperties) {
             <TableRow key="F">
               <TableCell>F</TableCell>
               <TableCell className="whitespace-normal">
-                Departure {getFormattedDepartureFrequency(scenario)}.
+                {hasDeparture &&
+                  `Departure ${getFormattedDepartureFrequency(scenario)}.`}
               </TableCell>
             </TableRow>
             <TableRow key="T">
               <TableCell>T</TableCell>
               <TableCell className="whitespace-normal">
-                Squawk {spellSquawk(scenario.plan.bcn?.toString() ?? "")}.
+                {hasSquawk &&
+                  `Squawk {spellSquawk(scenario.plan.bcn?.toString() ?? "")}.`}
               </TableCell>
             </TableRow>
           </TableBody>

--- a/apps/web/src/components/craft-table.tsx
+++ b/apps/web/src/components/craft-table.tsx
@@ -5,6 +5,7 @@ import {
   getFormattedClearanceLimit,
   getFormattedDepartureFrequency,
   getTelephony,
+  spellSquawk,
 } from "@workspace/plantools";
 import { Scenario } from "@workspace/validators";
 
@@ -84,7 +85,7 @@ export function CraftTable({ scenario, className }: CraftTableProperties) {
               <TableCell>T</TableCell>
               <TableCell className="whitespace-normal">
                 {hasSquawk &&
-                  `Squawk {spellSquawk(scenario.plan.bcn?.toString() ?? "")}.`}
+                  `Squawk ${spellSquawk(scenario.plan.bcn?.toString() ?? "")}.`}
               </TableCell>
             </TableRow>
           </TableBody>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The table now only displays "Departure" and "Squawk" information when relevant data is present.
  - The component will not render if all key CRAFT data is missing, resulting in a cleaner interface.
- **Bug Fixes**
  - Improved conditional display of "Departure" and "Squawk" rows for more accurate information presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->