### PR TITLE
Get rid of placeholder on eq field

### DIFF
--- a/apps/web/src/components/scenario-form/plan-section.tsx
+++ b/apps/web/src/components/scenario-form/plan-section.tsx
@@ -287,7 +287,7 @@ export function PlanSection({ isEditMode }: PlanSectionProperties) {
               <FormItem>
                 <FormLabel htmlFor="eq">EQ</FormLabel>
                 <FormControl>
-                  <Input id="eq" placeholder="L" {...field} />
+                  <Input id="eq" {...field} />
                 </FormControl>
                 <FormMessage />
               </FormItem>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Removed the placeholder text from the "EQ" field in the flight plan form for a cleaner input appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->