### PR TITLE
Get rid of rate limiting in the API server

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -25,7 +25,6 @@
     "express": "^5.1.0",
     "express-jwt-authz": "^2.4.1",
     "express-oauth2-jwt-bearer": "^1.6.1",
-    "express-rate-limit": "^7.5.0",
     "express-winston": "^4.2.0",
     "logform": "^2.7.0",
     "mongoose": "^8.13.2",

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -9,7 +9,6 @@ import { corsOptions, setWhitelist } from "./lib/cors.js";
 import { ENV } from "./lib/environment.js";
 import { logger } from "./lib/logger.js";
 import applyMiddleware from "./middleware/index.js";
-import { rateLimiter } from "./middleware/rate-limit.js";
 import healthRoutes from "./routes/health/index.js";
 import addRoutes from "./routes/index.js";
 
@@ -73,7 +72,6 @@ function startHealthServer() {
 
     // Security
     app.use(cors(corsOptions));
-    app.use(rateLimiter);
 
     healthApp.use("/health", healthRoutes);
 
@@ -100,7 +98,6 @@ async function startServer() {
 
     // Security
     app.use(cors(corsOptions));
-    app.use(rateLimiter);
 
     // Middleware and routes
     applyMiddleware(app);

--- a/apps/api/src/lib/environment.ts
+++ b/apps/api/src/lib/environment.ts
@@ -8,8 +8,6 @@ config({
 
 const environmentSchema = z
   .object({
-    API_RATE_LIMIT_MAX: z.coerce.number().default(120),
-    API_RATE_LIMIT_MINUTE_WINDOW: z.coerce.number().default(1),
     AUTH0_AUDIENCE: auth0url.optional(), // Optional, but should be a valid URL
     AUTH0_DOMAIN: auth0url.optional(), // Optional, but should be a valid URL
     DISABLE_AUTH: z

--- a/apps/api/src/middleware/apikey.ts
+++ b/apps/api/src/middleware/apikey.ts
@@ -2,18 +2,11 @@ import { ENV } from "@lib/environment.js";
 import { logger } from "@lib/logger.js";
 import { ApiKeyModel } from "@models/api-key.js";
 import { type NextFunction, type Request, type Response } from "express";
-import rateLimit from "express-rate-limit";
 
 const log = logger.child({ service: "apikey" });
 
-const apiKeyLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs
-  message: { error: "Too many attempts, please try again later" },
-});
-
 // Verifies that a valid api key was provided in the web request.
-export const verifyApiKeyRaw = async function (
+export const verifyApiKey = async function (
   request: Request,
   response: Response,
   next: NextFunction,
@@ -54,5 +47,3 @@ export const verifyApiKeyRaw = async function (
 
   next();
 };
-
-export const verifyApiKey = [apiKeyLimiter, verifyApiKeyRaw];

--- a/apps/api/src/middleware/rate-limit.ts
+++ b/apps/api/src/middleware/rate-limit.ts
@@ -1,9 +1,0 @@
-import { ENV } from "@lib/environment.js";
-import rateLimit from "express-rate-limit";
-
-export const rateLimiter = rateLimit({
-  windowMs: ENV.API_RATE_LIMIT_MINUTE_WINDOW * 60 * 1000, // 5 minute default
-  max: ENV.API_RATE_LIMIT_MAX, // Limit each IP to 100 requests per window
-  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
-  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ importers:
       express-oauth2-jwt-bearer:
         specifier: ^1.6.1
         version: 1.6.1
-      express-rate-limit:
-        specifier: ^7.5.0
-        version: 7.5.0(express@5.1.0)
       express-winston:
         specifier: ^4.2.0
         version: 4.2.0(winston@3.17.0)


### PR DESCRIPTION
Fixes #569

Not needed since Cloudflare provides rate limiting.