### PR TITLE
Don't show H/ or S/ in the FPE

### DIFF
--- a/packages/vatsim/src/utilities.ts
+++ b/packages/vatsim/src/utilities.ts
@@ -1,8 +1,6 @@
 export function splitAircraftType(
   rawAircraftType?: string,
 ): [string?, string?] {
-  let isHeavy = false;
-  let isSuper = false;
   let equipmentCode: string | undefined = undefined;
   let equipmentSuffix: string | undefined = undefined;
 
@@ -11,26 +9,17 @@ export function splitAircraftType(
   }
 
   if (rawAircraftType.startsWith("H/")) {
-    isHeavy = true;
     rawAircraftType = rawAircraftType.slice(2); // Strip off the leading "H/"
   }
 
   if (rawAircraftType.startsWith("S/")) {
-    isSuper = true;
     rawAircraftType = rawAircraftType.slice(2); // Strip off the leading "S/"
   }
 
   const codeMatch = /^([A-Z0-9]+)(\/([A-Z]))?$/.exec(rawAircraftType);
 
   if (codeMatch != undefined && codeMatch.length > 0) {
-    // Add back the prefix if isHeavy or isSuper is true
-    if (isHeavy) {
-      equipmentCode = `H/${codeMatch[1]}`;
-    } else if (isSuper) {
-      equipmentCode = `S/${codeMatch[1]}`;
-    } else {
-      equipmentCode = codeMatch[1];
-    }
+    equipmentCode = codeMatch[1];
 
     if (codeMatch.length > 2 && codeMatch[3].length > 0) {
       equipmentSuffix = codeMatch[3];


### PR DESCRIPTION
Fixes #591

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated aircraft type parsing to exclude "H/" (heavy) and "S/" (super) prefixes from the returned equipment code. The core aircraft type code is now returned without these prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->