### PR TITLE
Change CI workflows

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -2,6 +2,9 @@ name: Deploy - dev
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   docker:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Lint
 
 on:
   pull_request:
@@ -15,7 +15,7 @@ env:
 
 jobs:
   monorepo:
-    name: Build monorepo
+    name: Lint monorepo
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -51,47 +51,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        run: pnpx turbo run ci --affected
-
       - name: Lint
         run: pnpm lint:md && pnpx turbo lint --affected
-
-  docker:
-    name: Build Docker image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Check for changed Dockerfile
-        id: changed-files
-        uses: tj-actions/changed-files@v46
-        with:
-          since_last_remote_commit: true
-          files_yaml: |
-            dockerfile:
-              - apps/api/Dockerfile
-              - apps/api/.dockerignore
-              - .github/workflows/ci.yaml
-
-      - name: Skip if Dockerfiles unchanged
-        if: steps.changed-files.outputs.dockerfile_any_changed != 'true'
-        run: echo "No Dockerfile changes, skipping build."
-
-      - name: Docker build (CI only, no push)
-        if: steps.changed-files.outputs.dockerfile_any_changed == 'true'
-        uses: ./.github/actions/docker-build
-        with:
-          version: dev
-          push: false
-          tag_latest: false
-          turbo_token: ${{ secrets.TURBO_TOKEN }}
-          turbo_team: ${{ vars.TURBO_TEAM }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
 
     return config;
   },
+  typedRoutes: true,
 };
 
 export default nextConfig;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 
+/** @type {import('next').NextConfig} */
 const nextConfig: NextConfig = {
   // From https://dopoto.github.io/blog/20250217-nextjs-serializing-big-strings
   webpack: (config: { cache: { type: string } }) => {
@@ -9,7 +10,6 @@ const nextConfig: NextConfig = {
 
     return config;
   },
-  typedRoutes: true,
 };
 
 export default nextConfig;

--- a/apps/web/src/components/admin-header.tsx
+++ b/apps/web/src/components/admin-header.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Button } from "@/components/ui/button";
 import { CirclePlusIcon, LogOut } from "lucide-react";
+import type { Route } from "next";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo } from "react";
@@ -43,7 +44,6 @@ export function AdminHeader() {
 
     for (const [index, segment] of slicedSegments.entries()) {
       const hrefPath = "/" + slicedSegments.slice(0, index + 1).join("/");
-      const href = { pathname: hrefPath };
       const isLast = index === slicedSegments.length - 1;
       const label = friendlyNames[segment] ?? segment.replaceAll("-", " ");
 
@@ -53,7 +53,7 @@ export function AdminHeader() {
             <BreadcrumbLink aria-current="page">{label}</BreadcrumbLink>
           ) : (
             <BreadcrumbLink asChild>
-              <Link href={href}>{label}</Link>
+              <Link href={pathname as Route}>{label}</Link>
             </BreadcrumbLink>
           )}
         </BreadcrumbItem>,

--- a/apps/web/src/components/admin-header.tsx
+++ b/apps/web/src/components/admin-header.tsx
@@ -42,12 +42,13 @@ export function AdminHeader() {
     const elements: React.ReactNode[] = [];
 
     for (const [index, segment] of slicedSegments.entries()) {
-      const href = "/" + slicedSegments.slice(0, index + 1).join("/");
+      const hrefPath = "/" + slicedSegments.slice(0, index + 1).join("/");
+      const href = { pathname: hrefPath };
       const isLast = index === slicedSegments.length - 1;
       const label = friendlyNames[segment] ?? segment.replaceAll("-", " ");
 
       elements.push(
-        <BreadcrumbItem key={href}>
+        <BreadcrumbItem key={hrefPath}>
           {isLast ? (
             <BreadcrumbLink aria-current="page">{label}</BreadcrumbLink>
           ) : (
@@ -59,7 +60,7 @@ export function AdminHeader() {
       );
 
       if (!isLast) {
-        elements.push(<BreadcrumbSeparator key={`${href}-sep`} />);
+        elements.push(<BreadcrumbSeparator key={`${hrefPath}-sep`} />);
       }
     }
 

--- a/apps/web/src/components/admin-sidebar/admin-sidebar.tsx
+++ b/apps/web/src/components/admin-sidebar/admin-sidebar.tsx
@@ -13,6 +13,7 @@ import {
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
 import { ChartPie, Edit, Home } from "lucide-react";
+import type { Route } from "next";
 import Link from "next/link";
 
 const items = [
@@ -47,7 +48,7 @@ export function AdminSidebar({ ...properties }) {
                 {items.map((item) => (
                   <SidebarMenuItem key={item.title}>
                     <SidebarMenuButton asChild>
-                      <Link href={item.url}>
+                      <Link href={item.url as Route}>
                         <item.icon aria-hidden="true" />
                         <span>{item.title}</span>
                       </Link>

--- a/apps/web/src/components/markdown.tsx
+++ b/apps/web/src/components/markdown.tsx
@@ -1,3 +1,4 @@
+import type { Route } from "next";
 import Link from "next/link";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -14,7 +15,7 @@ const Markdown = ({ children }: MarkdownProperties) => {
         a: ({ href, children }) => (
           <Link
             className="text-[var(--color-primary)] underline"
-            href={href ?? "#"}
+            href={(href ?? "#") as Route}
             target="_blank"
             rel="noreferrer noopener"
           >

--- a/apps/web/src/components/pie-chart.tsx
+++ b/apps/web/src/components/pie-chart.tsx
@@ -8,6 +8,7 @@ import {
   Tooltip,
   type InteractionItem,
 } from "chart.js";
+import type { Route } from "next";
 import { useRouter } from "next/navigation";
 import { useMemo, useRef, type MouseEvent } from "react";
 import { Chart, getElementAtEvent } from "react-chartjs-2";
@@ -77,7 +78,7 @@ export default function PieChart({
 
     const filterValue = isBoolean ? item === "Yes" : `%22${item}%22`;
 
-    router.push(`${baseUrl}${filterValue}`);
+    router.push(`${baseUrl}${filterValue}` as Route);
   };
 
   const onClick = (event: MouseEvent<HTMLCanvasElement>) => {


### PR DESCRIPTION
- Standalone lint
- Dev deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Dev deployment workflow now also runs on pull requests targeting main (in addition to manual runs).
  - CI workflow renamed to “Lint”; build and Docker jobs removed while install and lint steps remain; monorepo job renamed accordingly.
  - Next.js config cleaned up (type annotation added, typedRoutes removed).
- Refactor
  - Breadcrumb routing updated to build per-segment hrefs and pass href as an object (no visible behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->